### PR TITLE
Updated to version 1.3.1 

### DIFF
--- a/WAkka/Wakka/WAkka.fsproj
+++ b/WAkka/Wakka/WAkka.fsproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>net48;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <PackageVersion>1.3.0</PackageVersion>
-    <AssemblyVersion>1.3.0</AssemblyVersion>
-    <FileVersion>1.3.0</FileVersion>
+    <PackageVersion>1.3.1</PackageVersion>
+    <AssemblyVersion>1.3.1</AssemblyVersion>
+    <FileVersion>1.3.1</FileVersion>
     <Authors>Wyatt Technology</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageReadmeFile>readme.md</PackageReadmeFile>


### PR DESCRIPTION
Updated to version 1.3.1 to disambiguate with the final Wyatt internal version (which was 1.3.0)