### PR TITLE
snapshot testing

### DIFF
--- a/WAkka/WAkkaTests/EventSourcedTests.fs
+++ b/WAkka/WAkkaTests/EventSourcedTests.fs
@@ -61,7 +61,7 @@ let ``spawn with name`` () =
                         handle ()
                     )
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
         
         let m1 = {value = 1234}
         act.Tell(m1, Akka.Actor.ActorRefs.NoSender)
@@ -92,7 +92,7 @@ let ``spawn with no name`` () =
                         handle ()
                     )
             }
-        let act = spawnNoSnapshots tk.Sys Props.Anonymous start
+        let act = spawnNoSnapshots tk.Sys EventSourcedProps.Anonymous start
 
         let m1 = {value = 1234}
         act.Tell(m1, Akka.Actor.ActorRefs.NoSender)
@@ -115,7 +115,7 @@ let ``get actor gives correct actor ref`` () =
                 let! act = getActor ()
                 do! typed probe <! act
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") (handle ())
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle ())
 
         probe.ExpectMsg act |> ignore
 
@@ -129,7 +129,7 @@ let ``map gives the correct result`` () =
                 let! act = getActor () |> mapResult (fun a -> Result<IActorRef<obj>, unit>.Ok a)
                 do! ActorRefs.typed probe <! act
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") (handle ())
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle ())
 
         let expected : Result<IActorRef<obj>, unit> = Ok act
         probe.ExpectMsg expected |> ignore
@@ -144,7 +144,7 @@ let ``get actor context gives correct actor`` () =
                 let! act = unsafeGetActorCtx ()
                 do! typed probe <! act.Self
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") (handle ())
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle ())
 
         probe.ExpectMsg (untyped act) |> ignore
 
@@ -166,7 +166,7 @@ let ``stop action calls stop handlers and stops the actor`` () =
                 // The actor should stop on the previous line so this message should never be sent
                 do! typed probe <! "should not get this"
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") (handle ())
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle ())
 
         tk.Watch (untyped act) |> ignore
         let m1 = {value = 1234}
@@ -190,7 +190,7 @@ let ``stop action in perist stops the actor`` () =
                 })
                 // The actor should stop on the previous line so this message should never be sent
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") (handle ())
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle ())
 
         tk.Watch (untyped act) |> ignore
         let m1 = {value = 1234}
@@ -215,7 +215,7 @@ let ``restart after stop results in stopped actor`` () =
                 do! typed probe <! $"should not get this ({num})"
                 // The actor should stop on the previous line so this message should never be sent
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") (handle 1)
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle 1)
 
         tk.Watch (untyped act) |> ignore
         probe.ExpectMsg (sent 1) |> ignore
@@ -224,7 +224,7 @@ let ``restart after stop results in stopped actor`` () =
         tk.ExpectTerminated (untyped act) |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
 
-        let act2 = spawnNoSnapshots tk.Sys (Props.Named "test") (handle 2)
+        let act2 = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle 2)
         tk.Watch (untyped act2) |> ignore
         tk.ExpectTerminated (untyped act2, timeout = TimeSpan.FromSeconds 30.0) |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -241,13 +241,13 @@ let ``create actor can create an actor`` () =
         let rec handle () =
             actor {
                 let! _newAct = createChild (fun parent ->
-                    spawnNoSnapshots parent Props.Anonymous child
+                    spawnNoSnapshots parent EventSourcedProps.Anonymous child
                 )
                 let! _ = persistSimple(Receive.Any ())
                 return! handle ()
             }
         let _act : ActorRefs.IActorRef<Msg> =
-            spawnNoSnapshots tk.Sys (Props.Named "test") (handle ())
+            spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle ())
 
         probe.ExpectMsg("created") |> ignore
 
@@ -260,7 +260,7 @@ let ``watch works`` () =
             let! _ = persistSimple(Receive.Only<string> ())
             return ()
         }
-        let watched = spawnNoSnapshots tk.Sys (Props.Named "watched") (otherActor ())
+        let watched = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "watched") (otherActor ())
 
         let rec handle () =
             actor {
@@ -276,7 +276,7 @@ let ``watch works`` () =
             do! typed probe <! ""
             return! handle ()
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg "" |> ignore
         (retype watched).Tell("", Akka.Actor.ActorRefs.NoSender)
@@ -291,7 +291,7 @@ let ``unwatch works`` () =
             let! _ = persistSimple(Receive.Only<string> ())
             return ()
         }
-        let watched = spawnNoSnapshots tk.Sys (Props.Named "watched") (otherActor ())
+        let watched = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "watched") (otherActor ())
 
         let rec handle () =
             actor {
@@ -312,7 +312,7 @@ let ``unwatch works`` () =
             do! typed probe <! "watched"
             return! handle ()
         }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg "watched" |> ignore
         (retype act).Tell("", Akka.Actor.ActorRefs.NoSender)
@@ -335,7 +335,7 @@ let ``schedule works`` () =
             do! typed probe <! "scheduled"
             return! handle ()
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg "scheduled" |> ignore
         (tk.Sys.Scheduler :?> Akka.TestKit.TestScheduler).Advance (TimeSpan.FromMilliseconds 99.0)
@@ -363,7 +363,7 @@ let ``scheduled messages can be cancelled`` () =
             do! typed probe <! "scheduled"
             return! handle ()
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg "scheduled" |> ignore
         (tk.Sys.Scheduler :?> Akka.TestKit.TestScheduler).Advance (TimeSpan.FromMilliseconds 100.0)
@@ -389,7 +389,7 @@ let ``schedule repeatedly works`` () =
             do! typed probe <! "scheduled"
             return! handle ()
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg "scheduled" |> ignore
         (tk.Sys.Scheduler :?> Akka.TestKit.TestScheduler).Advance (TimeSpan.FromMilliseconds 99.0)
@@ -424,7 +424,7 @@ let ``get sender get's the correct actor`` () =
                 do! typed probe <! ActorRefs.untyped sender
                 return! handle ()
             }
-        let act = spawnNoSnapshots tk.Sys (Props.Named "test") (handle ())
+        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle ())
 
         act.Tell("message", probe)
         probe.ExpectMsg probe |> ignore
@@ -441,7 +441,7 @@ let ``select get's the correct selection`` () =
             let! selection = select path
             do! typed probe <! selection
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         let msg = probe.ExpectMsg<Akka.Actor.ActorSelection> ()
         msg.PathString |> shouldEqual (probeAct.Path.ToStringWithoutAddress())
@@ -458,7 +458,7 @@ let ``for loop runs expected number of times`` () =
             do! typed probe <! "done"
         }
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         for i in indexes do
             probe.ExpectMsg $"{i}" |> ignore
@@ -474,7 +474,7 @@ let ``map array process all elements`` () =
             let! res =  [|1; 2; 3|] |> mapArray (fun i -> actor{return (i + 1)})
             do! typed probe <! res
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg [|2; 3; 4|] |> ignore
 
@@ -487,7 +487,7 @@ let ``map list process all elements`` () =
             let! res =  [1; 2; 3] |> mapList (fun i -> actor{return (i + 1)})
             do! typed probe <! res
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg [2; 3; 4] |> ignore
 
@@ -502,7 +502,7 @@ let ``foldActions processes all elements`` () =
             let! res =  (0, actions) ||> foldActions (fun i r -> actor{return (r + i)})
             do! typed probe <! res
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg (List.sum values) |> ignore
 
@@ -516,7 +516,7 @@ let ``foldValues processes all elements`` () =
             let! res =  (0, values) ||> foldValues (fun i r -> actor{return (r + i)})
             do! typed probe <! res
         }
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") start
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") start
 
         probe.ExpectMsg (List.sum values) |> ignore
 
@@ -540,7 +540,7 @@ let ``state is recovered when actor starts again using custom persistence id`` (
             return! outer ""
         }
         
-        let act1 = spawnNoSnapshots tk.Sys (Props.PersistenceId("test-id", actorName = "act1")) action
+        let act1 = spawnNoSnapshots tk.Sys (EventSourcedProps.PersistenceId("test-id", actorName = "act1")) action
         tellNow act1 "1"
         tellNow act1 "2"
         tellNow act1 "3"
@@ -550,7 +550,7 @@ let ``state is recovered when actor starts again using custom persistence id`` (
         tellNow (retype act1) Akka.Actor.PoisonPill.Instance
         tk.ExpectTerminated (untyped act1) |> ignore //make sure actor stops before starting new one
         
-        let act2 = spawnNoSnapshots tk.Sys (Props.PersistenceId("test-id", "act2")) action
+        let act2 = spawnNoSnapshots tk.Sys (EventSourcedProps.PersistenceId("test-id", "act2")) action
         let res2 = (retype act2).Ask<string>("get", Some (TimeSpan.FromMilliseconds 500.0)) |> Async.RunSynchronously
         res2 |> shouldEqual "123"
         
@@ -574,7 +574,7 @@ let ``state is recovered when actor starts again using default persistence id`` 
             return! outer ""
         }
         
-        let act1 = spawnNoSnapshots tk.Sys (Props.Named "test-id") action
+        let act1 = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test-id") action
         tellNow act1 "1"
         tellNow act1 "2"
         tellNow act1 "3"
@@ -584,7 +584,7 @@ let ``state is recovered when actor starts again using default persistence id`` 
         tellNow (retype act1) Akka.Actor.PoisonPill.Instance
         tk.ExpectTerminated (untyped act1) |> ignore //make sure actor stops before starting new one
         
-        let act2 = spawnNoSnapshots tk.Sys (Props.Named "test-id") action
+        let act2 = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test-id") action
         let res2 = (retype act2).Ask<string>("get", Some (TimeSpan.FromMilliseconds 500.0)) |> Async.RunSynchronously
         res2 |> shouldEqual "123"
         
@@ -630,7 +630,7 @@ let ``state is recovered after a crash`` () =
         let start = Simple.actor {
             let! crasher =
                 createChild (fun f ->
-                    spawnNoSnapshots f (Props.Named "crasher") crashStart
+                    spawnNoSnapshots f (EventSourcedProps.Named "crasher") crashStart
                 )
             do! typed probe <! crasher
             let! _ = Receive.Any ()
@@ -686,7 +686,7 @@ let ``state is recovered after a crash with simple persist`` () =
         let start = Simple.actor {
             let! crasher =
                 createChild (fun f ->
-                    spawnNoSnapshots f (Props.Named "crasher") crashStart
+                    spawnNoSnapshots f (EventSourcedProps.Named "crasher") crashStart
                 )
             do! typed probe <! crasher
             let! _ = Receive.Any ()
@@ -730,7 +730,7 @@ let ``isRecovering gives correct results`` () =
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
         
-        let _act = spawnNoSnapshots tk.Sys (Props.Named "test") (recoveryTestAction (typed probe))
+        let _act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (recoveryTestAction (typed probe))
 
         probe.ExpectMsg "Was recovering at start" |> ignore
         probe.ExpectMsg "Got RecoveryDone" |> ignore

--- a/WAkka/WAkkaTests/EventSourcedTests.fs
+++ b/WAkka/WAkkaTests/EventSourcedTests.fs
@@ -32,6 +32,7 @@ module WAkkaTests.EventSourcedTests
 
 open System
 
+open Akka.Actor
 open NUnit.Framework
 open FsUnitTyped
 
@@ -196,37 +197,6 @@ let ``stop action in perist stops the actor`` () =
         let m1 = {value = 1234}
         act.Tell(m1, Akka.Actor.ActorRefs.NoSender)
         tk.ExpectTerminated (untyped act) |> ignore
-        probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
-
-[<Test>]
-let ``restart after stop results in stopped actor`` () =
-    TestKit.testDefault <| fun tk ->
-        let probe = tk.CreateTestProbe "probe"
-
-        let sent num = $"should get this first time({num})"
-
-        let rec handle num =
-            actor {
-                do! persistSimple (Simple.actor {
-                        do! typed probe <! sent num
-                        let! _ = Receive.Any ()
-                        return! stop ()
-                    })
-                do! typed probe <! $"should not get this ({num})"
-                // The actor should stop on the previous line so this message should never be sent
-            }
-        let act = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle 1)
-
-        tk.Watch (untyped act) |> ignore
-        probe.ExpectMsg (sent 1) |> ignore
-        let m1 = {value = 1234}
-        act.Tell(m1, Akka.Actor.ActorRefs.NoSender)
-        tk.ExpectTerminated (untyped act) |> ignore
-        probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
-
-        let act2 = spawnNoSnapshots tk.Sys (EventSourcedProps.Named "test") (handle 2)
-        tk.Watch (untyped act2) |> ignore
-        tk.ExpectTerminated (untyped act2, timeout = TimeSpan.FromSeconds 30.0) |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
 
 [<Test>]
@@ -751,4 +721,32 @@ let ``Actor class: isRecovering gives correct results`` () =
         probe.ExpectMsg "Got RecoveryDone" |> ignore
         probe.ExpectMsg "Was not recovering after RecoveryDone" |> ignore
     
+let tell (act: ActorRefs.IActorRef<'Msg>) (msg: 'Msg) =
+    act.Tell(msg, Akka.Actor.ActorRefs.NoSender)
+
+[<Test>]
+let ``filter only inside of persist works`` () =
+    //When testing alphas of 1.5.0 we found that using the timeout version of FilterOnly within a call to persistSimple,
+    //the actor would always crash because the filter was not applied and the continuation would try to cast the result
+    //to Option<`Result> instead of `Result. This test is to make sure that this is fixed.
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let rec handle () =
+            actor {
+                let! msg = persistSimple (Receive.FilterOnly<Msg>(TimeSpan.FromSeconds 10.0, fun msg -> msg.value % 2 = 0))
+                do! ActorRefs.typed probe <! msg
+                return! handle ()
+            }
+        let act = spawnNoSnapshots tk.Sys EventSourcedProps.Anonymous (handle ())
+
+        let otherMsg = "This should be ignored"
+        tell (retype act) otherMsg
+        let m0 = {value = 1}
+        tell (retype act) m0
+        let m1 = {value = 2}
+        tell (retype act) m1
+        probe.ExpectMsg(Some m1) |> ignore        
+
+
 //NOTE: If new tests are added for the event sourced actor, it should probably be added for snapshot actors as well

--- a/WAkka/Wakka/EventSourced.fs
+++ b/WAkka/Wakka/EventSourced.fs
@@ -47,9 +47,15 @@ type EventSourcedExtra<'Snapshot> =
     | Snapshot of 'Snapshot
     
 /// An action that can only be used directly in an event sourced actor (e.g. started using eventSourced).
-type EventSourcedAction<'Result, 'Snapshot> = ActionBase<'Result, EventSourcedExtra<'Snapshot>>
+type EventSourcedActionBase<'Result, 'Snapshot> = ActionBase<'Result, EventSourcedExtra<'Snapshot>>
+type NoSnapshotsAction<'Result> = EventSourcedActionBase<'Result, NoSnapshotExtra>
+type SnapshotAction<'Result, 'Snapshot> = EventSourcedActionBase<'Result, SnapshotExtra<'Snapshot>>
 
-let rec private bind (f: 'a -> EventSourcedAction<'b, 's>) (op: EventSourcedAction<'a, 's>) : EventSourcedAction<'b, 's> =
+/// Backwards compatible type alias for EventSourcedActionBase<'Result, NoSnapshotExtra>. Use NoSnapshotAction in
+/// new code instead of this.
+type EventSourcedAction<'Result> = EventSourcedActionBase<'Result, NoSnapshotExtra>
+
+let rec private bind (f: 'a -> EventSourcedActionBase<'b, 's>) (op: EventSourcedActionBase<'a, 's>) : EventSourcedActionBase<'b, 's> =
     bindBase f op
 
 type ActorBuilder () =
@@ -58,7 +64,7 @@ type ActorBuilder () =
     member this.ReturnFrom x = x
     member this.Zero () = Done ()
     member this.Combine(m1, m2) = this.Bind (m1, m2)
-    member this.Delay (f: unit -> EventSourcedAction<'t, 's>): (unit -> EventSourcedAction<'t, 's>) = f
+    member this.Delay (f: unit -> EventSourcedActionBase<'t, 's>): (unit -> EventSourcedActionBase<'t, 's>) = f
     member this.Run f = f ()
     member this.For(values, f) : ActionBase<unit, 't> =
         match Seq.tryHead values with
@@ -84,9 +90,9 @@ open EventSourcedActorPrivate
 
 module Internal = 
     type IActionHandler<'Snapshot> =
-        abstract member StartAction: EventSourcedAction<unit, 'Snapshot>
-        abstract member SnapshotHandler: obj -> EventSourcedAction<unit, 'Snapshot>
-        abstract member HandleSnapshotExtra: 'Snapshot -> Akka.Persistence.UntypedPersistentActor -> (obj -> EventSourcedAction<'a, 'Snapshot>) -> EventSourcedAction<'a, 'Snapshot>
+        abstract member StartAction: EventSourcedActionBase<unit, 'Snapshot>
+        abstract member SnapshotHandler: obj -> EventSourcedActionBase<unit, 'Snapshot>
+        abstract member HandleSnapshotExtra: 'Snapshot -> Akka.Persistence.UntypedPersistentActor -> (obj -> EventSourcedActionBase<'a, 'Snapshot>) -> EventSourcedActionBase<'a, 'Snapshot>
     
     type EventSourcedActorBase<'Snapshot>(
         persistenceId: Option<string>,
@@ -222,7 +228,7 @@ type private NoSnapshotHandler (startAction) =
 /// can be derived from this class instead.  
 /// </summary>
 /// <param name="startAction">The action for the actor to run.</param>
-type EventSourcedActor(startAction: EventSourcedAction<unit, NoSnapshotExtra>, ?persistenceId) =
+type EventSourcedActor(startAction: EventSourcedActionBase<unit, NoSnapshotExtra>, ?persistenceId) =
     inherit Internal.EventSourcedActorBase<NoSnapshotExtra>(persistenceId, NoSnapshotHandler startAction)
 
 type private SnapshotHandler<'Snapshot> (startAction, snapshotHandler) =
@@ -254,8 +260,8 @@ type private SnapshotHandler<'Snapshot> (startAction, snapshotHandler) =
 /// <param name="startAction">The action for the actor to run.</param>
 /// <param name="snapshotHandler">If a snapshot is offered by the persistence system then it will be passed to this function to generate and initial action to use instead of startAction.</param>
 type EventSourcedSnapshotActor<'Snapshot>(
-    startAction: EventSourcedAction<unit, SnapshotExtra<'Snapshot>>,
-    snapshotHandler: 'Snapshot -> EventSourcedAction<unit, SnapshotExtra<'Snapshot>>,
+    startAction: EventSourcedActionBase<unit, SnapshotExtra<'Snapshot>>,
+    snapshotHandler: 'Snapshot -> EventSourcedActionBase<unit, SnapshotExtra<'Snapshot>>,
     ?persistenceId
 ) =
     inherit Internal.EventSourcedActorBase<SnapshotExtra<'Snapshot>>(persistenceId, SnapshotHandler(startAction, snapshotHandler))
@@ -263,11 +269,11 @@ type EventSourcedSnapshotActor<'Snapshot>(
 /// <summary>
 /// The properties for an event sourced actor.
 /// </summary>
-type Props = {
+type EventSourcedProps = {
     /// The persistence id for the actor. If None then the actor's path will be used.
     persistenceId: Option<string>
     /// The common properties for the actor.
-    common: Common.Props
+    common: Props
 }
 with
     /// <summary>
@@ -276,7 +282,7 @@ with
     /// <param name="name">The name for the actor.</param>
     static member Named name = {
         persistenceId = None
-        common = Common.Props.Named name
+        common = Props.Named name
     }
     
     /// <summary>
@@ -284,7 +290,7 @@ with
     /// </summary>
     static member Anonymous = {
         persistenceId = None
-        common = Common.Props.Anonymous
+        common = Props.Anonymous
     }
     
     /// <summary>
@@ -296,8 +302,8 @@ with
         persistenceId = Some id
         common =
             match actorName with
-            | Some n -> Common.Props.Named n
-            | None -> Common.Props.Anonymous 
+            | Some n -> Props.Named n
+            | None -> Props.Anonymous 
     }
     
 /// <summary>
@@ -306,7 +312,7 @@ with
 /// <param name="parent">The parent for the new actor.</param>
 /// <param name="props">The actor's properties.</param>
 /// <param name="action">The action to run.</param>
-let spawnNoSnapshots (parent: Akka.Actor.IActorRefFactory) (props: Props) (action: EventSourcedAction<unit, NoSnapshotExtra>) =
+let spawnNoSnapshots (parent: Akka.Actor.IActorRefFactory) (props: EventSourcedProps) (action: EventSourcedActionBase<unit, NoSnapshotExtra>) =
     let applyMod arg modifier current =
         match arg with
         | Some a -> modifier a current
@@ -330,9 +336,9 @@ let spawnNoSnapshots (parent: Akka.Actor.IActorRefFactory) (props: Props) (actio
 /// <param name="snapshotHandler">Called to generate the action to run based on the given snapshot.</param>
 let spawnSnapshots
     (parent: Akka.Actor.IActorRefFactory)
-    (props: Props)
-    (action: EventSourcedAction<unit, SnapshotExtra<'Snapshot>>)
-    (snapshotHandler: 'Snapshot -> EventSourcedAction<unit, SnapshotExtra<'Snapshot>>)
+    (props: EventSourcedProps)
+    (action: EventSourcedActionBase<unit, SnapshotExtra<'Snapshot>>)
+    (snapshotHandler: 'Snapshot -> EventSourcedActionBase<unit, SnapshotExtra<'Snapshot>>)
     =
     let applyMod arg modifier current =
         match arg with
@@ -351,7 +357,7 @@ let spawnSnapshots
 [<AutoOpen>]
 module Actions =
 
-    let private persistObj (action: Simple.SimpleAction<obj>): EventSourcedAction<obj, 's> =
+    let private persistObj (action: Simple.SimpleAction<obj>): EventSourcedActionBase<obj, 's> =
         Extra (RunAction action, Done)        
     
     /// The result of applying persist to a SimpleAction.
@@ -374,7 +380,7 @@ module Actions =
     /// ActionExecuted values will be read from the event log until it runs out, at which point persist will return a
     /// RecoveryDone value (the action will not have been executed, if it's result is needed then call persist again
     /// to execute the action). If the persistence system rejects a result, then ActionResultRejected will be returned. 
-    let persist (action: Simple.SimpleAction<'Result>): EventSourcedAction<PersistResult<'Result>, 'Snapshot> =
+    let persist (action: Simple.SimpleAction<'Result>): EventSourcedActionBase<PersistResult<'Result>, 'Snapshot> =
         let rec getEvt () = actor {
             let! evt = persistObj (Simple.actor {
                 let! res = action
@@ -402,7 +408,7 @@ module Actions =
     /// events and if recovery fails or a result is rejected by the persistence system , then it will stop the actor.
     /// If a result is produced then it was either read from the event log if recovering or the product of executing the
     /// action if not recovering. Unlike persist, persistSimple will always execute its action.
-    let persistSimple (action: Simple.SimpleAction<'Result>): EventSourcedAction<'Result, 'Snapshot> =
+    let persistSimple (action: Simple.SimpleAction<'Result>): EventSourcedActionBase<'Result, 'Snapshot> =
         let rec getEvt () = actor {
             let! evt = persistObj (Simple.actor {
                 let! res = action
@@ -425,12 +431,10 @@ module Actions =
         getEvt ()
 
     /// Gets the recovery state of the actor.
-    let isRecovering () : EventSourcedAction<bool, 'Snapshot> = actor {
+    let isRecovering () : EventSourcedActionBase<bool, 'Snapshot> = actor {
         let! res = Extra(GetRecovering, Done)
         return (res :?> bool)
     }
-    
-    type SnapshotAction<'Result, 'SnapShot> = EventSourcedAction<'Result, SnapshotExtra<'SnapShot>>
     
     /// Gets the sequence number of the last persistence operation.
     let getLastSequenceNumber () : SnapshotAction<int64, 'SnapShot> = actor {
@@ -467,7 +471,7 @@ module Actions =
     }
     
 ///Maps the given function over the given array within an actor expression.
-let mapArray (func: 'a -> EventSourcedAction<'b, 's>) (values: 'a []) : EventSourcedAction<'b [], 's> =
+let mapArray (func: 'a -> EventSourcedActionBase<'b, 's>) (values: 'a []) : EventSourcedActionBase<'b [], 's> =
     let rec loop (results: 'b []) i = ActorBuilder () {
         if i < values.Length then
             let! res = func values[i]
@@ -479,7 +483,7 @@ let mapArray (func: 'a -> EventSourcedAction<'b, 's>) (values: 'a []) : EventSou
     loop (Array.zeroCreate values.Length) 0
 
 ///Maps the given function over the given list within an actor expression.
-let mapList (func: 'a -> EventSourcedAction<'b, 's>) (values: List<'a>) : EventSourcedAction<List<'b>, 's> =
+let mapList (func: 'a -> EventSourcedActionBase<'b, 's>) (values: List<'a>) : EventSourcedActionBase<List<'b>, 's> =
     let rec loop (left: List<'a>) (results: List<'b>) = ActorBuilder () {
         match left with
         | head::tail ->
@@ -491,7 +495,7 @@ let mapList (func: 'a -> EventSourcedAction<'b, 's>) (values: List<'a>) : EventS
     loop values []
 
 ///Folds the given function over the given sequence of actions within an actor expression.
-let foldActions (func: 'a -> 'res -> EventSourcedAction<'res, 's>) (init: 'res) (values: seq<EventSourcedAction<'a, 's>>) : EventSourcedAction<'res, 's> =
+let foldActions (func: 'a -> 'res -> EventSourcedActionBase<'res, 's>) (init: 'res) (values: seq<EventSourcedActionBase<'a, 's>>) : EventSourcedActionBase<'res, 's> =
     let rec loop left cur = actor {
         if Seq.isEmpty left then
             return cur
@@ -503,7 +507,7 @@ let foldActions (func: 'a -> 'res -> EventSourcedAction<'res, 's>) (init: 'res) 
     loop values init
 
 ///Folds the given function over the given sequence within an actor expression.
-let foldValues (func: 'a -> 'res -> EventSourcedAction<'res, 's>) (init: 'res) (values: seq<'a>) : EventSourcedAction<'res, 's> =
+let foldValues (func: 'a -> 'res -> EventSourcedActionBase<'res, 's>) (init: 'res) (values: seq<'a>) : EventSourcedActionBase<'res, 's> =
     let rec loop left cur = ActorBuilder () {
         if Seq.isEmpty left then
             return cur

--- a/WAkka/Wakka/Spawn.fs
+++ b/WAkka/Wakka/Spawn.fs
@@ -35,7 +35,7 @@ type ActorType =
     private
     | NotPersisted of Simple.SimpleAction<unit>
     | Checkpointed of Simple.SimpleAction<unit>
-    | EventSourced of EventSourced.EventSourcedAction<unit, EventSourced.NoSnapshotExtra>
+    | EventSourced of EventSourced.EventSourcedActionBase<unit, EventSourced.NoSnapshotExtra>
 
 /// Creates an actor that goes back to the given action if it restarts. NOTE: This function is deprecated,
 /// use Simple.spawnNotPersisted instead.

--- a/WAkka/Wakka/WAkka.fsproj
+++ b/WAkka/Wakka/WAkka.fsproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>net48;netstandard2.0;netstandard2.1</TargetFrameworks>
-    <PackageVersion>1.5.0-alpha</PackageVersion>
+    <PackageVersion>1.5.0-alpha2</PackageVersion>
     <AssemblyVersion>1.5.0</AssemblyVersion>
     <FileVersion>1.5.0</FileVersion>
     <Authors>Wyatt Technology</Authors>


### PR DESCRIPTION
Fixed some issues found in testing the new snapshot code:

- Some type changes broke existing code
- Persistent actors that stop were persisting a "stop" event that would cause the actor to always stop if it was started again. 
- Some simple actions used in persist actions were not executing correctly (e.g. FilterOnly with a timeout)