### PR TITLE
Improved snapshot handling

### DIFF
--- a/PerformanceTest/PerformanceTest.fsproj
+++ b/PerformanceTest/PerformanceTest.fsproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka" Version="1.5.31" />
+      <PackageReference Include="Akka" Version="1.5.38" />
       <PackageReference Include="Argu" Version="6.2.4" />
       <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
       <PackageReference Update="FSharp.Core" Version="8.0.403" />

--- a/WAkka/WAkkaTests/CheckpointedTests.fs
+++ b/WAkka/WAkkaTests/CheckpointedTests.fs
@@ -37,7 +37,7 @@ open Akkling
 open WAkka.Common
 open WAkka.Simple
 
-let tell (act: ActorRefs.IActorRef<'Msg>) (msg: 'Msg) =
+let tell (act: IActorRef<'Msg>) (msg: 'Msg) =
     act.Tell(msg, Akka.Actor.ActorRefs.NoSender)
 
 type CrashMsg = {
@@ -56,7 +56,7 @@ let ``state is recovered after a crash`` () =
             match! Receive.Any () with
             | :? string as msg ->
                 let newRecved = msg :: recved
-                do! ActorRefs.typed probe <! String.concat "," newRecved
+                do! typed probe <! String.concat "," newRecved
                 return! crashHandle newRecved
             | :? CrashIt ->
                 failwith "crashing"
@@ -80,7 +80,7 @@ let ``state is recovered after a crash`` () =
                 createChild (fun f ->
                     spawnCheckpointed f (Props.Named "crasher") crashStart
                 )
-            do! ActorRefs.typed probe <! crasher
+            do! typed probe <! crasher
             return! handle ()
         }
         let parentProps = {
@@ -89,7 +89,7 @@ let ``state is recovered after a crash`` () =
         }
         let _parent = spawnCheckpointed tk.Sys parentProps start
 
-        let crasher : ActorRefs.IActorRef<string> = ActorRefs.retype (probe.ExpectMsg<ActorRefs.IActorRef<obj>> ())
+        let crasher : IActorRef<string> = retype (probe.ExpectMsg<IActorRef<obj>> ())
         let msg1 = "1"
         tell crasher msg1
         probe.ExpectMsg msg1 |> ignore

--- a/WAkka/WAkkaTests/EventSourcedTests.fs
+++ b/WAkka/WAkkaTests/EventSourcedTests.fs
@@ -596,7 +596,7 @@ let ``state is recovered after a crash`` () =
             return! crashHandle []
         }
 
-        let start = Simple.actor {
+        let start () = Simple.actor {
             let! crasher =
                 createChild (fun f ->
                     Spawn.NoSnapshots(f, EventSourcedProps.Named "crasher", crashStart)
@@ -609,7 +609,7 @@ let ``state is recovered after a crash`` () =
             Common.Props.Named "parent" with
                 supervisionStrategy = Strategy.OneForOne (fun _err -> Akka.Actor.Directive.Restart) |> Some
         }
-        let _parent = Simple.spawnNotPersisted tk.Sys parentProps start
+        let _parent = Simple.Spawn.NotPersisted(tk.Sys, parentProps, start)
 
         let crasher : IActorRef<string> = retype (probe.ExpectMsg<IActorRef<obj>> ())
         events.ExpectMsg PersistResult<List<string>>.RecoveryDone |> ignore
@@ -652,7 +652,7 @@ let ``state is recovered after a crash with simple persist`` () =
             return! crashHandle []
         }
 
-        let start = Simple.actor {
+        let start () = Simple.actor {
             let! crasher =
                 createChild (fun f ->
                     Spawn.NoSnapshots(f, EventSourcedProps.Named "crasher", crashStart)
@@ -665,7 +665,7 @@ let ``state is recovered after a crash with simple persist`` () =
             Common.Props.Named "parent" with
                 supervisionStrategy = Strategy.OneForOne (fun _err -> Akka.Actor.Directive.Restart) |> Some
         }
-        let _parent = Simple.spawnNotPersisted tk.Sys parentProps start
+        let _parent = Simple.Spawn.NotPersisted(tk.Sys, parentProps, start)
 
         let crasher : IActorRef<string> = retype (probe.ExpectMsg<IActorRef<obj>> ())
         let msg1 = "1"

--- a/WAkka/WAkkaTests/EventSourcedTests.fs
+++ b/WAkka/WAkkaTests/EventSourcedTests.fs
@@ -490,6 +490,67 @@ let ``foldValues processes all elements`` () =
         probe.ExpectMsg (List.sum values) |> ignore
 
 [<Test>]
+let ``actor stops if persistSimple gets a rejection`` () =
+    use tk = new Akka.Persistence.TestKit.PersistenceTestKit()
+    let t = tk.WithJournalWrite((fun w -> w.Reject()), fun () ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let rec start () =
+            actor {
+                let! _msg = 
+                    persistSimple (
+                        Simple.actor {
+                            let! msg = Receive.Only<Msg> ()
+                            do! (typed probe) <! msg
+                            return msg
+                        }
+                    )
+                return! start ()
+            }
+        let act = Spawn.NoSnapshots(tk.Sys, EventSourcedProps.Named "test", start)
+        tk.Watch (untyped act) |> ignore
+        let m1 = {value = 1234}
+        act.Tell(m1, Akka.Actor.ActorRefs.NoSender)
+        probe.ExpectMsg(m1, TimeSpan.FromSeconds 60.0) |> ignore
+        tk.ExpectTerminated (untyped act) |> ignore
+    )
+    t.Wait()
+
+[<Test>]
+let ``get proper result when persist gets rejected`` () =
+    use tk = new Akka.Persistence.TestKit.PersistenceTestKit()
+    let t = tk.WithJournalWrite((fun w -> w.Reject()), fun () ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let rec start () =
+            actor {
+                let! res = 
+                    persist (
+                        Simple.actor {
+                            let! msg = Receive.Only<Msg> ()
+                            do! (typed probe) <! msg
+                            return msg
+                        }
+                    )
+                do! typed probe <! res
+                return! start ()
+            }
+        let act = Spawn.NoSnapshots(tk.Sys, EventSourcedProps.Named "test", start)
+        let _recoveryDone = probe.ExpectMsg()
+        let m1 = {value = 1234}
+        act.Tell(m1, Akka.Actor.ActorRefs.NoSender)
+        probe.ExpectMsg(m1, TimeSpan.FromSeconds 60.0) |> ignore
+        let msg = probe.ExpectMsg<PersistResult<Msg>>()
+        match msg with
+        | ActionResultRejected(_result, _reason, _sequenceNr) -> ()
+        | other -> Assert.Fail $"Expected ActionResultRejected but got {other}"
+        let m2 = {value = 12345}
+        act.Tell(m2, Akka.Actor.ActorRefs.NoSender)
+        probe.ExpectMsg(m2, TimeSpan.FromSeconds 60.0) |> ignore
+    )
+    t.Wait()
+
+[<Test>]
 let ``state is recovered when actor starts again using custom persistence id`` () =
     TestKit.testDefault <| fun tk ->
         let action () = actor {
@@ -679,8 +740,6 @@ let ``state is recovered after a crash with simple persist`` () =
         let msg3 = "3"
         crasher.Tell(msg3, Akka.Actor.ActorRefs.NoSender)
         probe.ExpectMsg $"{msg3},{msg2},{msg1}"|> ignore
-
-//TODO: Needs tests for persistence rejection and recovery failure
 
 let recoveryTestAction probe () = actor {
     let! res1 = isRecovering ()

--- a/WAkka/WAkkaTests/NotPersistedTests.fs
+++ b/WAkka/WAkkaTests/NotPersistedTests.fs
@@ -37,7 +37,7 @@ open Akkling
 open WAkka.Common
 open WAkka.Simple
 
-let tell (act: ActorRefs.IActorRef<'Msg>) (msg: 'Msg) =
+let tell (act: IActorRef<'Msg>) (msg: 'Msg) =
     act.Tell(msg, Akka.Actor.ActorRefs.NoSender)
 
 
@@ -57,7 +57,7 @@ let ``state is not recovered after a crash`` () =
             match! Receive.Any () with
             | :? string as msg ->
                 let newRecved = msg :: recved
-                do! ActorRefs.typed probe <! String.concat "," newRecved
+                do! typed probe <! String.concat "," newRecved
                 return! crashHandle newRecved
             | :? CrashIt ->
                 failwith "crashing"
@@ -81,7 +81,7 @@ let ``state is not recovered after a crash`` () =
                 createChild (fun f ->
                     spawnNotPersisted f (Props.Named "crasher") crashStart
                 )
-            do! ActorRefs.typed probe <! crasher
+            do! typed probe <! crasher
             return! handle ()
         }
         let parentProps = {
@@ -90,7 +90,7 @@ let ``state is not recovered after a crash`` () =
         }
         let _parent = spawnNotPersisted tk.Sys parentProps start
 
-        let crasher : ActorRefs.IActorRef<string> = ActorRefs.retype (probe.ExpectMsg<ActorRefs.IActorRef<obj>> ())
+        let crasher : IActorRef<string> = retype (probe.ExpectMsg<IActorRef<obj>> ())
         let msg1 = "1"
         tell crasher msg1
         probe.ExpectMsg msg1 |> ignore

--- a/WAkka/WAkkaTests/SimpleTests.fs
+++ b/WAkka/WAkkaTests/SimpleTests.fs
@@ -40,9 +40,9 @@ open Akkling
 open WAkka.Common
 open WAkka.Simple
 
-type ActorFunction = Akka.Actor.IActorRefFactory -> Props -> SimpleAction<unit> -> IActorRef<obj>
+type ActorFunction = Akka.Actor.IActorRefFactory * Props * (unit -> SimpleAction<unit>) -> IActorRef<obj>
 let actorFunctions : ActorFunction [] =
-    [|spawnNotPersisted; spawnCheckpointed|]
+    [|Spawn.NotPersisted; Spawn.Checkpointed|]
 
 type Msg = {value: int}
 
@@ -66,7 +66,7 @@ let ``spawn with name`` ([<ValueSource("actorFunctions")>] makeActor: ActorFunct
                 do! typed probe <! msg
                 return! handle ()
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle ())
+        let act = makeActor(tk.Sys, Props.Named "test", handle)
 
         let m1 = {value = 1234}
         tell act m1
@@ -90,7 +90,7 @@ let ``spawn with no name`` ([<ValueSource("actorFunctions")>] makeActor: ActorFu
                 do! typed probe <! msg
                 return! handle ()
             }
-        let act = makeActor tk.Sys Props.Anonymous (handle ())
+        let act = makeActor(tk.Sys, Props.Anonymous, handle)
 
         let m1 = {value = 1234}
         tell act m1
@@ -117,7 +117,7 @@ let ``receive only ignores other messages by default`` ([<ValueSource("actorFunc
                     do! typed probe <! $"Got other message: {other.Value}"
                 return! handle ()
             }
-        let act = makeActor tk.Sys Props.Anonymous (handle ())
+        let act = makeActor(tk.Sys, Props.Anonymous, handle)
 
         tell (retype act) "This should be ignored"
         let m1 = {value = 1234}
@@ -138,7 +138,7 @@ let ``receive only with stash strategy stashes other messages`` ([<ValueSource("
                 do! typed probe <! other
                 return! handle ()
             }
-        let act = makeActor tk.Sys Props.Anonymous (handle ())
+        let act = makeActor(tk.Sys, Props.Anonymous, handle)
 
         let otherMsg = "This should be stash"
         tell (retype act) otherMsg
@@ -158,7 +158,7 @@ let ``receive filter only uses the filter`` ([<ValueSource("actorFunctions")>] m
                 do! typed probe <! msg
                 return! handle ()
             }
-        let act = makeActor tk.Sys Props.Anonymous (handle ())
+        let act = makeActor(tk.Sys, Props.Anonymous, handle)
 
         let otherMsg = "This should be ignored"
         tell (retype act) otherMsg
@@ -179,7 +179,7 @@ let ``receive filter only uses the filter with timeout`` ([<ValueSource("actorFu
                 do! typed probe <! msg
                 return! handle ()
             }
-        let act = makeActor tk.Sys Props.Anonymous (handle ())
+        let act = makeActor(tk.Sys, Props.Anonymous, handle)
 
         let otherMsg = "This should be ignored"
         tell (retype act) otherMsg
@@ -196,12 +196,16 @@ let ``receive any with timeout will timeout`` ([<ValueSource("actorFunctions")>]
 
         let expected = "test"
         
-        let _act = makeActor tk.Sys (Props.Named "test") (actor {
-           let! msg = Receive.Any(TimeSpan.FromMilliseconds 100.0)
-           match msg with
-           | Some _ -> do! typed probe <! msg
-           | None -> do! typed probe <! expected
-       })
+        let _act = makeActor(
+           tk.Sys,
+           Props.Named "test",
+           (fun () -> actor {
+               let! msg = Receive.Any(TimeSpan.FromMilliseconds 100.0)
+               match msg with
+               | Some _ -> do! typed probe <! msg
+               | None -> do! typed probe <! expected
+           })
+        )
         probe.ExpectNoMsg(TimeSpan.FromMilliseconds 100.0)
         let mutable tries = 0
         let mutable gotMsg = false
@@ -225,7 +229,7 @@ let ``get actor gives correct actor ref`` ([<ValueSource("actorFunctions")>] mak
                 let! act = getActor ()
                 do! typed probe <! (untyped act)
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle ())
+        let act = makeActor(tk.Sys, Props.Named "test", handle)
 
         probe.ExpectMsg (untyped act) |> ignore
 
@@ -240,7 +244,7 @@ let ``map gives the correct result`` ([<ValueSource("actorFunctions")>] makeActo
                 let! act = getActor () |> mapResult (fun a -> Result<IActorRef<obj>, unit>.Ok a)
                 do! typed probe <! act
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle ())
+        let act = makeActor(tk.Sys, Props.Named "test", handle)
 
         let expected : Result<IActorRef<obj>, unit> = Ok act
         probe.ExpectMsg expected |> ignore
@@ -255,7 +259,7 @@ let ``get actor context gives correct actor`` ([<ValueSource("actorFunctions")>]
                 let! act = unsafeGetActorCtx ()
                 do! typed probe <! act.Self
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle ())
+        let act = makeActor(tk.Sys, Props.Named "test", handle)
 
         probe.ExpectMsg (untyped act) |> ignore
 
@@ -272,7 +276,7 @@ let ``stop action stops the actor`` ([<ValueSource("actorFunctions")>] makeActor
                 // The actor should stop on the previous line so this message should never be sent
                 do! typed probe <! "should not get this"
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle ())
+        let act = makeActor(tk.Sys, Props.Named "test", handle)
 
         tk.Watch (untyped act) |> ignore
         let m1 = {value = 1234}
@@ -297,7 +301,7 @@ let ``create actor can create an actor`` ([<ValueSource("actorFunctions")>] make
                 do! ActorRefs.typed probe <! (untyped newAct)
             }
         let act : IActorRef<Msg> =
-            makeActor tk.Sys (Props.Named "test") (handle ()) |> retype
+            makeActor(tk.Sys, Props.Named "test", handle) |> retype
 
         probe.ExpectMsg (untyped act) |> ignore
         probe.ExpectMsg (untyped act) |> ignore
@@ -321,7 +325,7 @@ let ``unstash one only unstashes one message at a time`` ([<ValueSource("actorFu
                     do! stash ()
                     return! handle false
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle false)
+        let act = makeActor(tk.Sys, Props.Named "test", (fun () -> handle false))
 
         let m1 = {value = 1}
         tell act m1
@@ -362,7 +366,7 @@ let ``unstash all unstashes all the messages`` ([<ValueSource("actorFunctions")>
                     do! stash ()
                     return! handle false
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle false)
+        let act = makeActor(tk.Sys, Props.Named "test", (fun () -> handle false))
 
         let m1 = {value = 1}
         tell act m1
@@ -388,7 +392,7 @@ let ``watch works`` ([<ValueSource("actorFunctions")>] makeActor: ActorFunction)
             let! _ = Receive.Only<string> ()
             return ()
         }
-        let watched = makeActor tk.Sys (Props.Named "watched") (otherActor ())
+        let watched = makeActor(tk.Sys, Props.Named "watched", otherActor)
 
         let rec handle () =
             actor {
@@ -399,12 +403,12 @@ let ``watch works`` ([<ValueSource("actorFunctions")>] makeActor: ActorFunction)
                 | _msg ->
                     return! handle ()
             }
-        let start = actor {
+        let start () = actor {
             do! watch watched
             do! typed probe <! ""
             return! handle ()
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg "" |> ignore
         tell (retype watched) ""
@@ -419,7 +423,7 @@ let ``unwatch works`` ([<ValueSource("actorFunctions")>] makeActor: ActorFunctio
             let! _ = Receive.Only<string> ()
             return ()
         }
-        let watched = makeActor tk.Sys (Props.Named "watched") (otherActor ())
+        let watched = makeActor(tk.Sys, Props.Named "watched", otherActor)
 
         let rec handle () =
             actor {
@@ -434,12 +438,12 @@ let ``unwatch works`` ([<ValueSource("actorFunctions")>] makeActor: ActorFunctio
                 | _msg ->
                     return! handle ()
             }
-        let start = actor {
+        let start () = actor {
             do! watch watched
             do! typed probe <! "watched"
             return! handle ()
         }
-        let act = makeActor tk.Sys (Props.Named "test") start
+        let act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg "watched" |> ignore
         tell (retype act) ""
@@ -455,14 +459,14 @@ let ``termination wait works`` ([<ValueSource("actorFunctions")>] makeActor: Act
         let rec otherActor () = actor {
             do! Receive.Only<string> () |> ignoreResult
         }
-        let watched = makeActor tk.Sys (Props.Named "watched") (otherActor ())
+        let watched = makeActor(tk.Sys, Props.Named "watched", otherActor)
 
-        let start = actor {
+        let start () = actor {
             do! typed probe <! ""
             do! Termination.Wait(watched, stashOthers)            
             do! typed probe <! (untyped watched)
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg "" |> ignore
         tell (retype watched) ""
@@ -476,7 +480,7 @@ let ``termination wait timeout works`` ([<ValueSource("actorFunctions")>] makeAc
         let rec otherActor () = actor {
             do! Receive.Only<string> () |> ignoreResult
         }
-        let watched = makeActor tk.Sys (Props.Named "watched") (otherActor ())
+        let watched = makeActor(tk.Sys, Props.Named "watched", otherActor)
 
         let readyMsg = "ready"
         let doneMsg = "OnDone called"
@@ -489,7 +493,7 @@ let ``termination wait timeout works`` ([<ValueSource("actorFunctions")>] makeAc
                 member _.OnDone () = actor {do! typed probe <! doneMsg}
         }
         let timeoutMsg = "time out"
-        let start = actor {
+        let start () = actor {
             do! typed probe <! ""
             let! res = Termination.Wait(watched, TimeSpan.FromMilliseconds 100.0, others)
             if res then
@@ -497,7 +501,7 @@ let ``termination wait timeout works`` ([<ValueSource("actorFunctions")>] makeAc
             else
                 do! typed probe <! timeoutMsg
         }
-        let act = makeActor tk.Sys (Props.Named "test") start
+        let act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg "" |> ignore
         let _msg = act.Ask("", None) |> Async.RunSynchronously
@@ -517,12 +521,12 @@ let ``schedule works`` ([<ValueSource("actorFunctions")>] makeActor: ActorFuncti
                 let! _msg = Receive.Any ()
                 return! handle ()
             }
-        let start = actor {
+        let start () = actor {
             let! _cancel = schedule (TimeSpan.FromMilliseconds 100.0) (typed probe) "message"
             do! typed probe <! "scheduled"
             return! handle ()
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg "scheduled" |> ignore
         (tk.Sys.Scheduler :?> Akka.TestKit.TestScheduler).Advance (TimeSpan.FromMilliseconds 99.0)
@@ -544,13 +548,13 @@ let ``scheduled messages can be cancelled`` ([<ValueSource("actorFunctions")>] m
                 let! _msg = Receive.Any ()
                 return! handle ()
             }
-        let start = actor {
+        let start () = actor {
             let! cancel = schedule (TimeSpan.FromMilliseconds 100.0) (typed probe) "message"
             cancel.Cancel ()
             do! typed probe <! "scheduled"
             return! handle ()
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg "scheduled" |> ignore
         (tk.Sys.Scheduler :?> Akka.TestKit.TestScheduler).Advance (TimeSpan.FromMilliseconds 100.0)
@@ -571,12 +575,12 @@ let ``schedule repeatedly works`` ([<ValueSource("actorFunctions")>] makeActor: 
                 let! _msg = Receive.Any ()
                 return! handle ()
             }
-        let start = actor {
+        let start () = actor {
             let! _cancel = scheduleRepeatedly delay interval (typed probe) "message"
             do! typed probe <! "scheduled"
             return! handle ()
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg "scheduled" |> ignore
         (tk.Sys.Scheduler :?> Akka.TestKit.TestScheduler).Advance (TimeSpan.FromMilliseconds 99.0)
@@ -609,7 +613,7 @@ let ``get sender gets the correct actor`` ([<ValueSource("actorFunctions")>] mak
                 do! typed probe <! (untyped sender)
                 return! handle ()
             }
-        let act = makeActor tk.Sys (Props.Named "test") (handle ())
+        let act = makeActor(tk.Sys, Props.Named "test", handle)
 
         act.Tell("message", probe)
         probe.ExpectMsg probe |> ignore
@@ -627,11 +631,11 @@ let ``select gets the correct selection`` ([<ValueSource("actorFunctions")>] mak
                 let! _msg = Receive.Only<string> ()
                 return! handle ()
             }
-        let start = actor {
+        let start () = actor {
             let! selection = select path
             do! typed probe <! selection
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         let msg = probe.ExpectMsg<Akka.Actor.ActorSelection> ()
         msg.PathString |> shouldEqual (probeAct.Path.ToStringWithoutAddress())
@@ -642,7 +646,7 @@ let ``try without error gives correct results`` ([<ValueSource("actorFunctions")
         let probe = tk.CreateTestProbe "probe"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     return msg
@@ -652,7 +656,7 @@ let ``try without error gives correct results`` ([<ValueSource("actorFunctions")
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -663,7 +667,7 @@ let ``nested try without error gives correct results`` ([<ValueSource("actorFunc
         let probe = tk.CreateTestProbe "probe"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -677,7 +681,7 @@ let ``nested try without error gives correct results`` ([<ValueSource("actorFunc
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -689,7 +693,7 @@ let ``try with error after action gives correct results`` ([<ValueSource("actorF
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     let! _ = getActor ()
@@ -701,7 +705,7 @@ let ``try with error after action gives correct results`` ([<ValueSource("actorF
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -713,7 +717,7 @@ let ``nested try with error after action gives correct results`` ([<ValueSource(
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -729,7 +733,7 @@ let ``nested try with error after action gives correct results`` ([<ValueSource(
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -741,7 +745,7 @@ let ``try with error before action gives correct results`` ([<ValueSource("actor
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     doFail ()
@@ -752,7 +756,7 @@ let ``try with error before action gives correct results`` ([<ValueSource("actor
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -764,7 +768,7 @@ let ``nested try with error before action gives correct results`` ([<ValueSource
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -779,7 +783,7 @@ let ``nested try with error before action gives correct results`` ([<ValueSource
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -791,7 +795,7 @@ let ``nested try with error after action and error in handler after action gives
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -809,7 +813,7 @@ let ``nested try with error after action and error in handler after action gives
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -821,7 +825,7 @@ let ``nested try with error after action and error in handler before action give
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -838,7 +842,7 @@ let ``nested try with error after action and error in handler before action give
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -850,7 +854,7 @@ let ``nested try with error before action and error in handler after action give
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -867,7 +871,7 @@ let ``nested try with error before action and error in handler after action give
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -879,7 +883,7 @@ let ``nested try with error before action and error in handler before action giv
 
         let msg = "testing 1 2 3"
         let doFail () = failwith msg
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -895,7 +899,7 @@ let ``nested try with error before action and error in handler before action giv
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -908,7 +912,7 @@ let ``finally without error calls handler`` ([<ValueSource("actorFunctions")>] m
         let final = tk.CreateTestProbe "final"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     return msg
@@ -917,7 +921,7 @@ let ``finally without error calls handler`` ([<ValueSource("actorFunctions")>] m
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -930,7 +934,7 @@ let ``nested finally without error calls all handlers`` ([<ValueSource("actorFun
         let final = tk.CreateTestProbe "final"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -942,7 +946,7 @@ let ``nested finally without error calls all handlers`` ([<ValueSource("actorFun
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -956,7 +960,7 @@ let ``finally with error calls handler`` ([<ValueSource("actorFunctions")>] make
         let final = tk.CreateTestProbe "final"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -970,7 +974,7 @@ let ``finally with error calls handler`` ([<ValueSource("actorFunctions")>] make
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -983,7 +987,7 @@ let ``nested finally with error before actions calls all handlers`` ([<ValueSour
         let final = tk.CreateTestProbe "final"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -1000,7 +1004,7 @@ let ``nested finally with error before actions calls all handlers`` ([<ValueSour
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -1014,7 +1018,7 @@ let ``nested finally with error after actions calls all handlers`` ([<ValueSourc
         let final = tk.CreateTestProbe "final"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     try
@@ -1032,7 +1036,7 @@ let ``nested finally with error after actions calls all handlers`` ([<ValueSourc
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -1046,7 +1050,7 @@ let ``finally in with calls handler`` ([<ValueSource("actorFunctions")>] makeAct
         let final = tk.CreateTestProbe "final"
 
         let msg = "testing 1 2 3"
-        let start = actor {
+        let start () = actor {
             let! res = actor {
                 try
                     failwith msg
@@ -1061,7 +1065,7 @@ let ``finally in with calls handler`` ([<ValueSource("actorFunctions")>] makeAct
             }
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg msg |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -1081,11 +1085,11 @@ let ``using calls dispose`` ([<ValueSource("actorFunctions")>] makeActor: ActorF
             }
         }
 
-        let start = actor {
+        let start () = actor {
             use! disp = getDisposable ()
             do! typed probe <! disp
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg<IDisposable> () |> ignore
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
@@ -1097,13 +1101,13 @@ let ``for loop runs expected number of times`` ([<ValueSource("actorFunctions")>
         let probe = tk.CreateTestProbe "probe"
 
         let indexes = [1..10]
-        let start = actor {
+        let start () = actor {
             for i in indexes do
                 do! typed probe <! $"{i}"
             do! typed probe <! "done"
         }
         probe.ExpectNoMsg (TimeSpan.FromMilliseconds 100.0)
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         for i in indexes do
             probe.ExpectMsg $"{i}" |> ignore
@@ -1115,12 +1119,16 @@ let ``while loop runs as long as expected`` ([<ValueSource("actorFunctions")>] m
         let probe = tk.CreateTestProbe "probe"
         let mutable keepGoing = 0
         let mutable count = 0
-        let act = makeActor tk.Sys (Props.Named "test") (actor {
-           while keepGoing = 0 do
-               let! msg = Receive.Only<string> ()
-               System.Threading.Interlocked.Increment &count |> ignore
-               do! typed probe <! $"Got {msg}"
-        })
+        let act = makeActor(
+           tk.Sys,
+           Props.Named "test",
+           (fun () -> actor {
+               while keepGoing = 0 do
+                   let! msg = Receive.Only<string> ()
+                   System.Threading.Interlocked.Increment &count |> ignore
+                   do! typed probe <! $"Got {msg}"
+            })
+        )
         tk.Watch (untyped act) |> ignore
         for i in 1..10 do
             tellNow act $"{i}"
@@ -1145,7 +1153,7 @@ let ``execute while continues until done`` ([<ValueSource("actorFunctions")>] ma
     TestKit.testDefault <| fun tk ->
         let result = tk.CreateTestProbe "result"
 
-        let start = actor {
+        let start () = actor {
             do!
                 (fun i -> actor {
                     do! typed result <! WhileResult i
@@ -1157,7 +1165,7 @@ let ``execute while continues until done`` ([<ValueSource("actorFunctions")>] ma
                 })
             do! typed result <! WhileDoneResult
         }
-        let act = makeActor tk.Sys (Props.Named "test") start
+        let act = makeActor(tk.Sys, Props.Named "test", start)
 
         for i in 0 .. 10 do
             tellNow act (WhileValue i)
@@ -1170,11 +1178,11 @@ let ``map array process all elements`` ([<ValueSource("actorFunctions")>] makeAc
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
 
-        let start = actor {
+        let start () = actor {
             let! res =  [|1; 2; 3|] |> mapArray (fun i -> actor{return (i + 1)})
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg [|2; 3; 4|] |> ignore
 
@@ -1183,11 +1191,11 @@ let ``map list process all elements`` ([<ValueSource("actorFunctions")>] makeAct
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
 
-        let start = actor {
+        let start () = actor {
             let! res =  [1; 2; 3] |> mapList (fun i -> actor{return (i + 1)})
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg [2; 3; 4] |> ignore
 
@@ -1197,12 +1205,12 @@ let ``foldActions processes all elements`` ([<ValueSource("actorFunctions")>] ma
         let probe = tk.CreateTestProbe "probe"
 
         let values = [1; 2; 3]
-        let start = actor {
+        let start () = actor {
             let actions = values |> List.map actor.Return
             let! res =  (0, actions) ||> foldActions (fun i r -> actor{return (r + i)})
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg (List.sum values) |> ignore
 
@@ -1212,11 +1220,11 @@ let ``foldValues processes all elements`` ([<ValueSource("actorFunctions")>] mak
         let probe = tk.CreateTestProbe "probe"
 
         let values = [1; 2; 3]
-        let start = actor {
+        let start () = actor {
             let! res =  (0, values) ||> foldValues (fun i r -> actor{return (r + i)})
             do! typed probe <! res
         }
-        let _act = makeActor tk.Sys (Props.Named "test") start
+        let _act = makeActor(tk.Sys, Props.Named "test", start)
 
         probe.ExpectMsg (List.sum values) |> ignore
 
@@ -1225,12 +1233,12 @@ let ``sleep with stashing stashes messages`` ([<ValueSource("actorFunctions")>] 
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
 
-        let start = actor {
+        let start () = actor {
             do! sleep (TimeSpan.FromSeconds 1.0) stashOthers
             let! msg = Receive.Only<string>()
             do! typed probe <! $"got: {msg}"
         }
-        let act = makeActor tk.Sys (Props.Named "test") start
+        let act = makeActor(tk.Sys, Props.Named "test", start)
 
         let msg = "testing 1 2 3"
         tellNow act msg
@@ -1243,12 +1251,12 @@ let ``sleep with ignoring ignores messages`` ([<ValueSource("actorFunctions")>] 
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
 
-        let start = actor {
+        let start () = actor {
             do! sleep (TimeSpan.FromSeconds 1.0) ignoreOthers
             let! msg = Receive.Only<string>()
             do! typed probe <! $"got: {msg}"
         }
-        let act = makeActor tk.Sys (Props.Named "test") start
+        let act = makeActor(tk.Sys, Props.Named "test", start)
 
         let msg = "testing 1 2 3"
         tellNow act msg
@@ -1277,7 +1285,7 @@ let ``crash handlers are invoked if actor crashes`` ([<ValueSource("actorFunctio
             failwith "crashed"
             return! handle ()
         }
-        let crashStart = actor {
+        let crashStart () = actor {
             let! _ = setRestartHandler (fun (_ctx, msg, err) ->
                 tell (typed probe) {id = 1; msg = msg; err = err}
             )
@@ -1286,10 +1294,10 @@ let ``crash handlers are invoked if actor crashes`` ([<ValueSource("actorFunctio
             )
             return! crashHandle ()
         }
-        let start = actor {
+        let start () = actor {
             let! crasher =
                 createChild (fun f ->
-                    makeActor f (Props.Named "crasher") crashStart
+                    makeActor(f, Props.Named "crasher", crashStart)
                 )
             do! typed probe <! crasher
             return! handle ()
@@ -1298,7 +1306,7 @@ let ``crash handlers are invoked if actor crashes`` ([<ValueSource("actorFunctio
             Props.Named "parent" with
                 supervisionStrategy = Strategy.OneForOne (fun _err -> Akka.Actor.Directive.Restart) |> Some
         }
-        let _parent = makeActor tk.Sys parentProps start
+        let _parent = makeActor(tk.Sys, parentProps, start)
 
         let crasher = probe.ExpectMsg<IActorRef<obj>> ()
         tell (retype crasher) "crash it"
@@ -1322,7 +1330,7 @@ let ``crash handler is not invoked if handler is cleared`` ([<ValueSource("actor
             failwith "crashed"
             return! handle ()
         }
-        let crashStart = actor {
+        let crashStart () = actor {
             let! id = setRestartHandler (fun (_ctx, msg, err) ->
                 tell (typed probe) {id = 1; msg = msg; err = err}
             )
@@ -1333,10 +1341,10 @@ let ``crash handler is not invoked if handler is cleared`` ([<ValueSource("actor
             return! crashHandle()
         }
 
-        let start = actor {
+        let start () = actor {
             let! crasher =
                 createChild (fun f ->
-                    makeActor f (Props.Named "crasher") crashStart
+                    makeActor(f, Props.Named "crasher", crashStart)
                 )
             do! typed probe <! crasher
             return! handle ()
@@ -1345,7 +1353,7 @@ let ``crash handler is not invoked if handler is cleared`` ([<ValueSource("actor
             Props.Named "parent" with
                 supervisionStrategy = Strategy.OneForOne (fun _err -> Akka.Actor.Directive.Restart) |> Some
         }
-        let _parent = makeActor tk.Sys parentProps start
+        let _parent = makeActor(tk.Sys, parentProps, start)
 
         let crasher = probe.ExpectMsg<IActorRef<obj>> ()
         tell (retype crasher) "crash it"
@@ -1364,7 +1372,7 @@ let ``stop handlers are invoked if actor stops`` ([<ValueSource("actorFunctions"
             let! _  = Receive.Only<string> ()
             return! stop ()
         }
-        let start = actor {
+        let start () = actor {
             let! _ = setStopHandler (fun _ctx ->
                 tell (typed probe) {id = 1}
             )
@@ -1373,7 +1381,7 @@ let ``stop handlers are invoked if actor stops`` ([<ValueSource("actorFunctions"
             )
             return! handle ()
         }
-        let actor = makeActor tk.Sys (Props.Named "stopper") start
+        let actor = makeActor(tk.Sys, Props.Named "stopper", start)
 
         tell (retype actor) "stop it"
         let res = probe.ExpectMsg<StopMsg>()
@@ -1390,7 +1398,7 @@ let ``stop handler is not invoked if handler is cleared`` ([<ValueSource("actorF
             let! _  = Receive.Only<string> ()
             return! stop ()
         }
-        let start = actor {
+        let start () = actor {
             let! id = setStopHandler (fun _ctx ->
                 tell (typed probe) {id = 1}
             )
@@ -1400,7 +1408,7 @@ let ``stop handler is not invoked if handler is cleared`` ([<ValueSource("actorF
             do! clearStopHandler id
             return! handle ()
         }
-        let actor = makeActor tk.Sys (Props.Named "stopper") start
+        let actor = makeActor(tk.Sys, Props.Named "stopper", start)
 
         tell (retype actor) "stop it"
         let res = probe.ExpectMsg<StopMsg>()
@@ -1412,11 +1420,11 @@ let ``use HandleMessages at top-level`` ([<ValueSource("actorFunctions")>] makeA
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
 
-        let start = Receive.HandleMessages (fun msg ->
+        let start () = Receive.HandleMessages (fun msg ->
             tell (typed probe) msg
             HandleMessagesResult.IsDone ()
         )
-        let actor = makeActor tk.Sys (Props.Named "stopper") start
+        let actor = makeActor(tk.Sys, Props.Named "stopper", start)
         tk.Watch (untyped actor) |> ignore
         
         tell (retype actor) "stop it"
@@ -1428,12 +1436,12 @@ let ``use HandleMessages with context at top-level`` ([<ValueSource("actorFuncti
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
 
-        let start = Receive.HandleMessages (fun ctx msg ->
+        let start () = Receive.HandleMessages (fun ctx msg ->
             tell (typed probe) $"act: {ctx.GetSelf()}"
             tell (typed probe) msg
             HandleMessagesResult.IsDone ()
         )
-        let actor = makeActor tk.Sys (Props.Named "stopper") start
+        let actor = makeActor(tk.Sys, Props.Named "stopper", start)
         tk.Watch (untyped actor) |> ignore
         
         tell (retype actor) "stop it"
@@ -1446,11 +1454,11 @@ let ``use HandleMessages, continue with no state changes`` ([<ValueSource("actor
     TestKit.testDefault <| fun tk ->
         let probe = tk.CreateTestProbe "probe"
 
-        let start = Receive.HandleMessages (fun msg ->
+        let start () = Receive.HandleMessages (fun msg ->
             tell (typed probe) msg
             HandleMessagesResult.Continue
         )
-        let actor = makeActor tk.Sys (Props.Named "stopper") start
+        let actor = makeActor(tk.Sys, Props.Named "stopper", start)
 
         for i in 0 .. 10 do    
             tell (retype actor) $"{i}"
@@ -1469,7 +1477,7 @@ let ``use HandleMessages, continue with state changes`` ([<ValueSource("actorFun
             tell (typed probe) $"{msg.i}/{newAcc}"
             HandleMessagesResult.ContinueWith (handle newAcc)
             
-        let actor = makeActor tk.Sys (Props.Named "stopper") (Receive.HandleMessages (handle 0))
+        let actor = makeActor(tk.Sys, Props.Named "stopper", (fun () -> Receive.HandleMessages (handle 0)))
 
         for i in 0 .. 10 do    
             tell (retype actor) {i = i}
@@ -1489,7 +1497,7 @@ let ``use HandleMessages, continue with action`` ([<ValueSource("actorFunctions"
                 do! typed probe <! {i = msg1.i + msg2.i}
             }) 
             
-        let actor = makeActor tk.Sys (Props.Named "stopper") (Receive.HandleMessages handle)
+        let actor = makeActor(tk.Sys, Props.Named "stopper", (fun () -> Receive.HandleMessages handle))
         tk.Watch (untyped actor) |> ignore
 
         let i1 = 12
@@ -1510,7 +1518,7 @@ let ``HandleMessages ignores incorrect message type`` ([<ValueSource("actorFunct
             tell (typed probe) $"{msg.i}/{newAcc}"
             HandleMessagesResult.ContinueWith (handle newAcc)
             
-        let actor = spawn tk.Sys (Props.Named "stopper") (Receive.HandleMessages (handle 0))
+        let actor = spawn(tk.Sys, Props.Named "stopper", (fun () -> Receive.HandleMessages (handle 0)))
 
         for i in 0 .. 10 do    
             tell (retype actor) {i = i}
@@ -1530,10 +1538,11 @@ let ``HandleMessages gives correct result when used in actor expression`` ([<Val
             | Some prev -> HandleMessagesResult.IsDone (prev.i + msg.i)
             | None -> HandleMessagesResult.ContinueWith (handle (Some msg))
             
-        let actor = spawn tk.Sys (Props.Named "stopper") (actor {
-           let! res = Receive.HandleMessages (handle None)
-           do! typed probe <! {i = res}
-       })
+        let actor = spawn(tk.Sys, Props.Named "stopper", (fun () -> actor {
+               let! res = Receive.HandleMessages (handle None)
+               do! typed probe <! {i = res}
+           })
+        )
         tk.Watch (untyped actor) |> ignore
 
         let i1 = 12

--- a/WAkka/WAkkaTests/SnapshotTests.fs
+++ b/WAkka/WAkkaTests/SnapshotTests.fs
@@ -1305,7 +1305,7 @@ type TestPersistenceControl() =
                     logged <- (lvl, cause, msg)::logged
                 )
             |> ignore
-            Logger(akkaLogger.Object)
+            akkaLogger.Object
             
 [<Test>]
 let ``SnapshotResultHandler: deletes nothing`` () =

--- a/WAkka/WAkkaTests/SnapshotTests.fs
+++ b/WAkka/WAkkaTests/SnapshotTests.fs
@@ -599,7 +599,7 @@ let ``state is recovered after a crash`` () =
             return! crashHandle []
         }
 
-        let start = Simple.actor {
+        let start () = Simple.actor {
             let! crasher =
                 createChild (fun f ->
                     Spawn.WithSnapshots(f, EventSourcedProps.Named "crasher", constAction crashStart)
@@ -612,7 +612,7 @@ let ``state is recovered after a crash`` () =
             Common.Props.Named "parent" with
                 supervisionStrategy = Strategy.OneForOne (fun _err -> Akka.Actor.Directive.Restart) |> Some
         }
-        let _parent = Simple.spawnNotPersisted tk.Sys parentProps start
+        let _parent = Simple.Spawn.NotPersisted(tk.Sys, parentProps, start)
 
         let crasher : IActorRef<string> = retype (probe.ExpectMsg<IActorRef<obj>> ())
         events.ExpectMsg PersistResult<List<string>>.RecoveryDone |> ignore
@@ -655,7 +655,7 @@ let ``state is recovered after a crash with simple persist`` () =
             return! crashHandle []
         }
 
-        let start = Simple.actor {
+        let start () = Simple.actor {
             let! crasher =
                 createChild (fun f ->
                     Spawn.WithSnapshots(f, EventSourcedProps.Named "crasher", constAction crashStart)
@@ -668,7 +668,7 @@ let ``state is recovered after a crash with simple persist`` () =
             Common.Props.Named "parent" with
                 supervisionStrategy = Strategy.OneForOne (fun _err -> Akka.Actor.Directive.Restart) |> Some
         }
-        let _parent = Simple.spawnNotPersisted tk.Sys parentProps start
+        let _parent = Simple.Spawn.NotPersisted(tk.Sys, parentProps, start)
 
         let crasher : IActorRef<string> = retype (probe.ExpectMsg<IActorRef<obj>> ())
         let msg1 = "1"

--- a/WAkka/WAkkaTests/WAkkaTests.fsproj
+++ b/WAkka/WAkkaTests/WAkkaTests.fsproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <PackageReference Include="Akka" Version="1.5.31" />
       <PackageReference Include="Akka.Persistence.TestKit" Version="1.5.31" />
+      <PackageReference Include="Akka.Persistence.TestKit.Xunit2" Version="1.5.31" />
       <PackageReference Include="Akka.TestKit" Version="1.5.31" />
       <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.31" />
       <PackageReference Include="Akkling.TestKit" Version="0.16.2" />

--- a/WAkka/WAkkaTests/WAkkaTests.fsproj
+++ b/WAkka/WAkkaTests/WAkkaTests.fsproj
@@ -7,12 +7,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Akka" Version="1.5.31" />
-      <PackageReference Include="Akka.Persistence.TestKit" Version="1.5.31" />
-      <PackageReference Include="Akka.Persistence.TestKit.Xunit2" Version="1.5.31" />
-      <PackageReference Include="Akka.TestKit" Version="1.5.31" />
-      <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.31" />
-      <PackageReference Include="Akkling.TestKit" Version="0.16.2" />
+      <PackageReference Include="Akka" Version="1.5.38" />
+      <PackageReference Include="Akka.Persistence.TestKit" Version="1.5.38" />
+      <PackageReference Include="Akka.Persistence.TestKit.Xunit2" Version="1.5.38" />
+      <PackageReference Include="Akka.TestKit" Version="1.5.38" />
+      <PackageReference Include="Akka.TestKit.Xunit2" Version="1.5.38" />
+      <PackageReference Include="Akkling.TestKit" Version="0.17.0" />
       <PackageReference Include="altcover" Version="8.9.3" />
       <PackageReference Include="FsUnit" Version="4.1.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/WAkka/WAkkaTests/WAkkaTests.fsproj
+++ b/WAkka/WAkkaTests/WAkkaTests.fsproj
@@ -16,6 +16,7 @@
       <PackageReference Include="altcover" Version="8.9.3" />
       <PackageReference Include="FsUnit" Version="4.1.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+      <PackageReference Include="Moq" Version="4.20.72" />
       <PackageReference Include="NUnit" Version="3.13.2" />
       <PackageReference Update="FSharp.Core" Version="8.0.403" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/WAkka/Wakka/ActorResult.fs
+++ b/WAkka/Wakka/ActorResult.fs
@@ -186,7 +186,7 @@ module ActorResultCE =
     /// Result that the action evaluated to. If the result is "Ok okValue" then "okValue" is bound to "value". If the
     /// result is "Error err" then the "actorResult" CE terminates with a value of "Error err". Note that the right
     /// side of a "let! ... = ..." must evaluate to "SimpleAction<Result<'res, 'err>>". There are numerous functions in
-    /// the ActorResult module that can help convert other types (booleans, options, etc) into the proper type. The
+    /// the ActorResult module that can help convert other types (booleans, options, etc.) into the proper type. The
     /// "actorResult" CE produces a "Delayed<Result<'res, 'err>>" and must be passed to runActorResult for evaluation.
     let actorResult = ActorResultBuilder()
     /// Evaluates an actorResult computation expression.

--- a/WAkka/Wakka/Common.fs
+++ b/WAkka/Wakka/Common.fs
@@ -41,22 +41,28 @@ type Logger (logger: ILoggingAdapter) =
     /// The underlying Akka.NET logger.
     member _.Logger = logger
     
-    /// Log the given message at the given level.
+    /// Log the given message at the given level. In most cases it is better to use the methods of the Akka
+    /// ILoggingAdapter which can be obtained from the Logger property.
     member _.Log level (msg: string) = logger.Log (level, msg)
 
-    ///Log the given exception.
+    ///Log the given exception. In most cases it is better to use the methods of the Akka
+    /// ILoggingAdapter which can be obtained from the Logger property.
     member _.LogException (err: exn) = logger.Error err.Message
 
-    ///Log the given message at the debug level.
+    ///Log the given message at the debug level. In most cases it is better to use the methods of the Akka
+    /// ILoggingAdapter which can be obtained from the Logger property.
     member _.Debug (msg: string) = logger.Debug msg
 
-    ///Log the given message at the info level.
+    ///Log the given message at the info level. In most cases it is better to use the methods of the Akka
+    /// ILoggingAdapter which can be obtained from the Logger property.
     member _.Info (msg: string) = logger.Info msg
 
-    ///Log the given message at the warning level.
+    ///Log the given message at the warning level. In most cases it is better to use the methods of the Akka
+    /// ILoggingAdapter which can be obtained from the Logger property.
     member _.Warning (msg: string) = logger.Warning msg
 
-    ///Log the given message at the error level.
+    ///Log the given message at the error level. In most cases it is better to use the methods of the Akka
+    /// ILoggingAdapter which can be obtained from the Logger property.
     member _.Error (msg: string) = logger.Error msg
 
 /// An actor context.
@@ -169,9 +175,12 @@ module CommonActions =
     /// Gets the context for this actor. Normally, this should not be needed. All of its "safe" functionality can be invoked using actions.
     let unsafeGetActorCtx () = Simple (fun ctx -> Done (ctx :> IActorContext))
 
-    /// Gets the logger for this actor.
+    /// Gets the logger for this actor. In most cases it is better to use the methods of the Akka ILoggingAdapter which
+    /// can be obtained from getAkkaLogger instead of using this action.
     let getLogger () = Simple (fun ctx -> Done ctx.Logger)
-
+    /// Gets the Akka ILoggingAdapter for this actor.
+    let getAkkaLogger() = Simple (fun ctx -> Done ctx.Logger.Logger)
+    
     /// Stops this actor.
     let stop () =
         // This weird dance is here so that the result of stop can adapt to the context that it is called in, and

--- a/WAkka/Wakka/Common.fs
+++ b/WAkka/Wakka/Common.fs
@@ -33,9 +33,14 @@ module WAkka.Common
 open Akka.Event
 
 /// A logger tied to an actor.
-type Logger internal (ctx: Akka.Actor.IActorContext) =
-    let logger = Logging.GetLogger (ctx.System, ctx.Self.Path.ToStringWithAddress())
+type Logger (logger: ILoggingAdapter) =
 
+    new (ctx: Akka.Actor.IActorContext) =
+        Logger (Logging.GetLogger (ctx.System, ctx.Self.Path.ToStringWithAddress()))
+
+    /// The underlying Akka.NET logger.
+    member _.Logger = logger
+    
     /// Log the given message at the given level.
     member _.Log level (msg: string) = logger.Log (level, msg)
 

--- a/WAkka/Wakka/Common.fs
+++ b/WAkka/Wakka/Common.fs
@@ -76,11 +76,11 @@ type IActorContext =
     /// Get an actor selection for the given actor path.
     abstract member ActorSelection: Akka.Actor.ActorPath -> Akka.Actor.ActorSelection
 
-/// A function the can be passed to the setRestartHandler action. The function is passed the actor context, the message
+/// A function that can be passed to the setRestartHandler action. The function is passed the actor context, the message
 /// that was being processed when the crash happened, and the exception that caused the crash.
 type RestartHandler = IActorContext * obj * exn -> unit
 
-/// A function the can be passed to the setPostStopHandler action. The function is passed the actor context.
+/// A function that can be passed to the setPostStopHandler action. The function is passed the actor context.
 type StopHandler = IActorContext -> unit
 
 type internal IActionContext =
@@ -104,7 +104,7 @@ type Props = {
     deploy: Option<Akka.Actor.Deploy>
     /// Specifies an alternate router type.
     router: Option<Akka.Routing.RouterConfig>
-    /// Specifies an alternate supervision strategy type for this actors children.
+    /// Specifies an alternate supervision strategy type for this actor's children.
     supervisionStrategy: Option<Akka.Actor.SupervisorStrategy>
 }
 with
@@ -169,8 +169,8 @@ module CommonActions =
 
     /// Stops this actor.
     let stop () =
-        // This weird dance is here so that the result of stop can adapt to the context that is it called in and
-        // we dont have to do "do! stop (); return! something" and instead just do "return! stop ()" when an
+        // This weird dance is here so that the result of stop can adapt to the context that it is called in, and
+        // we don't have to do "do! stop (); return! something" and instead just do "return! stop ()" when an
         // Action<'Result, 'a> is expected and 'Result is not unit.
         bindBase (fun () -> Done Unchecked.defaultof<'Result>) (Stop Done)
 
@@ -179,7 +179,7 @@ module CommonActions =
     let createChild (make: Akka.Actor.IActorRefFactory -> 'Result) =
         Simple (fun ctx -> Done (make ctx.ActorFactory))
 
-    /// Sends a the given message to the given actor. Also see the "<!" operator.
+    /// Sends the given message to the given actor. Also see the "<!" operator.
     let send (recv: Akkling.ActorRefs.IActorRef<'Msg>) msg = Simple (fun ctx -> Done (recv.Tell (msg, ctx.Self)))
 
     /// Watches the given actor for termination with this actor.

--- a/WAkka/Wakka/EventSourced.fs
+++ b/WAkka/Wakka/EventSourced.fs
@@ -587,7 +587,8 @@ module Actions =
     }
     
     /// <summary>
-    /// A snapshot result handler for use with Spawn.WithSnapshots.
+    /// A snapshot result handler for use with addSnapshotResultHandler. Create an instance and pass its Handle method
+    /// to addSnapshotResultHandler.
     /// </summary>
     /// <param name="deletePriorMessages">
     /// If true, then on snapshot success, all persisted messages prior to the snapshot are deleted.

--- a/WAkka/Wakka/Simple.fs
+++ b/WAkka/Wakka/Simple.fs
@@ -129,8 +129,7 @@ let internal handleSimpleActions (
             handler ()
         with
         | err ->
-            let logger = Logger ctx
-            logger.Error $"Got exception when running finally handler: {err}"
+            ctx.GetLogger().Error(err, "Got exception when running finally handler")
 
     let rec handleActions (action: SimpleAction<obj>) =
         match action with
@@ -341,12 +340,12 @@ type SimpleActor (persist: bool, startAction: unit -> SimpleAction<unit>) as thi
     let mutable restartHandlers = LifeCycleHandlers.LifeCycleHandlers<IActorContext * obj * exn>()
     let mutable stopHandlers = LifeCycleHandlers.LifeCycleHandlers<IActorContext>()
     
-    let logger = Logger ctx
+    let logger = ctx.GetLogger()
 
     let mutable msgHandler = {
         new IMessageHandler with
             member this.HandleMessage msg =
-                logger.Error $"Received message before waitForStart installed: {msg}"
+                logger.Error("Received message before waitForStart installed: {0}", msg)
     }
 
     do

--- a/WAkka/Wakka/Simple.fs
+++ b/WAkka/Wakka/Simple.fs
@@ -564,7 +564,7 @@ module Actions =
     let stash () : SimpleAction<unit> = Simple (fun ctx -> Done (ctx.Stash.Stash ()))
     /// Unstashes the message at the front of the stash.
     let unstashOne () : SimpleAction<unit> = Simple (fun ctx -> Done (ctx.Stash.Unstash ()))
-    /// Unstashes all of the messages in the stash.
+    /// Unstashes all the messages in the stash.
     let unstashAll () : SimpleAction<unit> = Simple (fun ctx -> Done (ctx.Stash.UnstashAll ()))
 
     /// Strategy for dealing with "other messages" when using receive and sleep methods.

--- a/WAkka/Wakka/Spawn.fs
+++ b/WAkka/Wakka/Spawn.fs
@@ -38,14 +38,14 @@ type ActorType =
     | EventSourced of EventSourced.EventSourcedActionBase<unit, EventSourced.NoSnapshotExtra>
 
 /// Creates an actor that goes back to the given action if it restarts. NOTE: This function is deprecated,
-/// use Simple.spawnNotPersisted instead.
+/// use Simple.Spawn.NotPersisted instead.
 let notPersisted action = NotPersisted action
 /// Creates and actor that runs the given action. If the actor crashes then it restarts from the last point where it
-/// was waiting for a message.NOTE: This function is deprecated, use Simple.spawnCheckpointed instead.
+/// was waiting for a message. NOTE: This function is deprecated, use Simple.Spawn.Checkpointed instead.
 let checkpointed action = Checkpointed action
 /// Creates an actor that uses the Akka.NET persistence event sourcing mechanism. In the event of a restart, the actor
 /// will replay events that were stored using the EventSourced.Actions.persist action. NOTE: This function is deprecated,
-/// use EventSourced.spawnNoSnapshots or EventSourced.spawnSnapshots instead.
+/// use EventSourced.Spawn.NoSnapshots or EventSourced.Spawn.Snapshots instead.
 let eventSourced action = EventSourced action
 
 /// Creates a new actor that is a child of the given parent. The actor will be created using the given properties and
@@ -55,8 +55,8 @@ let spawn (parent: Akka.Actor.IActorRefFactory) (props: Common.Props) (actorType
 
     match actorType with
     | NotPersisted action ->
-        Simple.spawn parent props false action
+        Simple.spawn parent props false (fun () -> action)
     | Checkpointed action ->
-        Simple.spawn parent props true action
+        Simple.spawn parent props true (fun () -> action)
     | EventSourced action ->
         EventSourced.spawnNoSnapshots parent {persistenceId = None; common = props} action

--- a/WAkka/Wakka/WAkka.fsproj
+++ b/WAkka/Wakka/WAkka.fsproj
@@ -46,7 +46,4 @@
     <PackageReference Update="FSharp.Core" Version="8.0.403" />
     <PackageReference Include="FsToolkit.ErrorHandling" Version="2.13.0" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="../../readme.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
 </Project>

--- a/WAkka/Wakka/WAkka.fsproj
+++ b/WAkka/Wakka/WAkka.fsproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <PackageVersion>1.5.0-alpha3</PackageVersion>
-    <AssemblyVersion>1.5.0</AssemblyVersion>
-    <FileVersion>1.5.0</FileVersion>
+    <PackageVersion>1.5.1</PackageVersion>
+    <AssemblyVersion>1.5.1</AssemblyVersion>
+    <FileVersion>1.5.1</FileVersion>
     <Authors>Wyatt Technology</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
@@ -36,13 +36,13 @@
     <Compile Include="Spawn.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.5.31" />
-    <PackageReference Include="Akka.Persistence" Version="1.5.31" />
-    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.5.31" />
-    <PackageReference Include="Akka.Streams" Version="1.5.31" />
+    <PackageReference Include="Akka" Version="1.5.38" />
+    <PackageReference Include="Akka.Persistence" Version="1.5.38" />
+    <PackageReference Include="Akka.Serialization.Hyperion" Version="1.5.38" />
+    <PackageReference Include="Akka.Streams" Version="1.5.38" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Akkling" Version="0.16.2" />
-    <PackageReference Include="Akkling.Persistence" Version="0.16.2" />
+    <PackageReference Include="Akkling" Version="0.17.0" />
+    <PackageReference Include="Akkling.Persistence" Version="0.17.0" />
     <PackageReference Update="FSharp.Core" Version="8.0.403" />
     <PackageReference Include="FsToolkit.ErrorHandling" Version="2.13.0" />
   </ItemGroup>

--- a/readme.md
+++ b/readme.md
@@ -128,11 +128,10 @@ reaching the end of the CE will cause the actor to stop).
 
 ### Spawning Actors
 
-Actors are normally started using the static methods of the *Spawn* class defined in either the
+Actors are normally started using the static methods of the `Spawn` class defined in either the
 `WAkka.Simple` or `WAkka.EventSourced` modules. For specialized cases where an actor class is needed
 (e.g., remote deployment) please see Actor Classes [below](#alternate-spawning-via-actor-classes).
-The parent,
-properties, and action for the new actor are passed in. An `Akkling.ActorRefs.IActorRef<'Msg>`
+The parent, properties, and action for the new actor are passed in. An `Akkling.ActorRefs.IActorRef<'Msg>`
 pointing at the new actor is returned. The `'Msg` type is inferred from the calling context. If you
 want to fix the message type in the actor reference then wrap your call to spawn and actor in a
 function and specify the message type for the returned reference:
@@ -165,19 +164,19 @@ To start the two actors above one would do:
 ```f#
 open WAkka
 
-let act1 = Simple.spawnNotPersisted parent Context.Props.Anonymous (handle "")
-let act2 = Simple.spawnNotPersisted parent Context.Props.Anonymous workflow
+let act1 = Simple.Spawn.NotPersisted(parent, Context.Props.Anonymous, (fun () -> handle ""))
+let act2 = Simple.Spawn.NotPersisted(parent, Context.Props.Anonymous, (fun () -> workflow))
 ```
 
 In this case the actors were started with no persistence. To use checkpointing just substitute
-`Simple.spawnCheckpointed` for `Simple.spawnNotPersisted`.
+`Simple.Spawn.Checkpointed` for `Simple.Spawn.NotPersisted`.
 
 #### Deprecated Spawn Functions
 
-Before version 1.5, WAkka spawned actors using the functions in the `WAkka.Spawn` or various
-functions in the `WAkka.Simple` and `WAkka.EventSourced` module. Those functions still exist to
+Before version 1.5, WAkka spawned actors using the functions in the `WAkka.Spawn`,`WAkka.Simple`,
+and `WAkka.EventSourced` modules. Those functions still exist to
 support backwards compatibility, but should not be used in new code. The static members of
-the `Spawn` class in each of those modules should be used instead.
+the `Spawn` class in the `WAkka.Simple` and `WAkka.EventSourced` modules should be used instead.
 
 #### Alternate spawning via actor classes
 
@@ -255,7 +254,7 @@ The `Common` module also contains functions to change the result type of an acti
 #### Simple actions
 
 These actions can only be used directly in a simple actor (i.e. those started with
-`Simple.spawnNotPersisted` or `Simple.spawnCheckpointed`)
+`Simple.Spawn.NotPersisted` or `Simple.Spawn.Checkpointed`)
 
 * `Receive`: Static methods of this class are used to receive messages. Each method has an optional
   timeout and those that filter messages have a *strategy* for dealing with messages that are

--- a/readme.md
+++ b/readme.md
@@ -214,8 +214,10 @@ These actions can be used directly in both simple and event sourced actors.
 * `getActor`: Get the reference for this actor.
 * `unsafeGetActorCtx`: Gets the actor context for this actor as a `WAkka.Context.IActorContext`.
   Normally this context is not needed, its functionality is available through the built-in actions.
+* `getAkkaLogger`: Gets a `Akka.Event.ILoggingAdapter` for the current actor. 
 * `getLogger`: Gets an `WAkka.Logger.Logger` for this actor which can be used to log messages
-  through the Akka.NET logging system.
+  through the Akka.NET logging system. This action is gor backwards compatibility, `getAkkaLogger`
+  should be used instead.
 * `stop`: Stops this actor.
 * `createChild`: Creates a child of this actor. The given function will be passed an
   `IActorRefFactory` to use when creating the new actor.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,12 @@
 # WAkka (aka Wyatt Akka)
 
-This is another interface for using [Akka.NET](https://getakka.net) from F#. The computation expression approach in both the standard F# interface for Akka.NET and [Akkling](https://github.com/Horusiath/Akkling) breaks composability. The type associated with the computation expression is `Effect<'Msg>` and a computation expression must always evaluate to this type. This means that you can't implement a function that filters messages and then call that from within the actor computation expression. For example, the following will not work:
+This is another interface for using [Akka.NET](https://getakka.net) from F#. The computation
+expression approach in both the standard F# interface for Akka.NET
+and [Akkling](https://github.com/Horusiath/Akkling) breaks composability. The type associated with
+the computation expression is `Effect<'Msg>` and a computation expression must always evaluate to
+this type. This means that you can't implement a function that filters messages and then call that
+from within the actor computation expression. For example, the following will not work:
+
 ```f#
 open Akkling
 
@@ -23,7 +29,8 @@ let printMsg =
     }
 ```
 
-`filterMsgs` must evaluate to an `Effect<Msg>` which `printMsg` can do nothing with. Using WAkka, the above can be done as:
+`filterMsgs` must evaluate to an `Effect<Msg>` which `printMsg` can do nothing with. Using WAkka,
+the above can be done as:
 
 ```f#
 open WAkka.Simple
@@ -49,20 +56,46 @@ let printMsg =
 
 ## Should you use this?
 
-That's always a difficult question to answer in a general fashion for a library since every possible user of the library is working under different constraints. One question that will affect everyone: is it stable? As far as we can tell the answer is yes. The library has been through multiple iterations internally at Wyatt Technology in multiple products and appears to be solid. That being said, as with all open source software, no warranty is implied or given. 
+That's always a difficult question to answer in a general fashion for a library since every possible
+user of the library is working under different constraints. One question that will affect everyone:
+is it stable? As far as we can tell the answer is yes. The library has been through multiple
+iterations internally at Wyatt Technology in multiple products and appears to be solid. That being
+said, as with all open source software, no warranty is implied or given.
 
-Performance of actors built with the `actor` computation expression (see [below](#actions)) lags behind those built using Akka or Akkling. In the simple test case given in the PerformanceTest project, the actor implemented using the computation expression gets around 55-60% of the message processing rate that Akka and Akkling can achieve. On a 2021 Apple M1 Processor, this still worked out to be around 900K messages per second. For us at Wyatt Technology this is way beyond our needs. Your needs may be different, so keep this limitation in mind. If an actor is built using `HandleMessages`, then performance on par with Akkling can be achieved if `ContinueWith` is used for state management, and parity with Akka can be achieved if mutable state and `Continue` is used (see [below](#handlemessages)).  
+Performance of actors built with the `actor` computation expression (see [below](#actions)) lags
+behind those built using Akka or Akkling. In the simple test case given in the PerformanceTest
+project, the actor implemented using the computation expression gets around 55-60% of the message
+processing rate that Akka and Akkling can achieve. On a 2021 Apple M1 Processor, this still worked
+out to be around 900K messages per second. For us at Wyatt Technology this is way beyond our needs.
+Your needs may be different, so keep this limitation in mind. If an actor is built using
+`HandleMessages`, then performance on par with Akkling can be achieved if `ContinueWith` is used for
+state management, and parity with Akka can be achieved if mutable state and `Continue` is used (
+see [below](#handlemessages)).
 
 ## Usage
 
-WAkka is built on top of Akka.NET and Akkling. It uses the typed actor references from Akkling, and the general infrastructure from Akka.NET. The actor system should be started as though you're using Akkling. Then, the creation of actors should be done as shown below. 
+WAkka is built on top of Akka.NET and Akkling. It uses the typed actor references from Akkling, and
+the general infrastructure from Akka.NET. The actor system should be started as though you're using
+Akkling. Then, the creation of actors should be done as shown below.
 
-Note that the Akkling `<!` (*tell* operator) can cause unexpected behavior in WAkka computation expressions. In order to avoid this, WAkka also overrides this operator to behave properly in computation expressions. If both WAkka and Akkling modules are opened, then WAkka must be opened after Akkling so that WAkka's definition of the operator will be used. To send messages outside of a computation expression, the `tellNow` function is provided (open the `WAkka.Common` module to use it).
+Note that the Akkling `<!` (*tell* operator) can cause unexpected behavior in WAkka computation
+expressions. In order to avoid this, WAkka also overrides this operator to behave properly in
+computation expressions. If both WAkka and Akkling modules are opened, then WAkka must be opened
+after Akkling so that WAkka's definition of the operator will be used. To send messages outside a
+computation expression, the `tellNow` function is provided (open the `WAkka.Common` module to use
+it).
 
 ### Actions
-In WAkka, actors are implemented using the `actor` CE which evaluates to `ActionBase<'Type, 'ActorType>` where `'Type` is the type that the action evaluates to and `'ActorType` is used to restrict certain actions to certain types of actors(e.g., those that use or don't use persistence). The elements of the `actor` CE themselves evaluate to `ActionBase<'Type, 'ActorType>`. For example, the `Receive.Any` action used above evaluates to `ActionBase<obj, 'ActorType>` meaning that it will evaluate to an `obj` when a message is available.
 
-Recursion is used to process more than one message. For example, an actor that just processes each message that it receives, possibly keeping some sort of state, can be implemented as:
+In WAkka, actors are implemented using the `actor` CE which evaluates to
+`ActionBase<'Type, 'ActorType>` where `'Type` is the type that the action evaluates to and
+`'ActorType` is used to restrict certain actions to certain types of actors(e.g., those that use or
+don't use persistence). The elements of the `actor` CE themselves evaluate to
+`ActionBase<'Type, 'ActorType>`. For example, the `Receive.Any` action used above evaluates to
+`ActionBase<obj, 'ActorType>` meaning that it will evaluate to an `obj` when a message is available.
+
+Recursion is used to process more than one message. For example, an actor that just processes each
+message that it receives, possibly keeping some sort of state, can be implemented as:
 
 ```f#
 open WAkka.Simple
@@ -76,7 +109,8 @@ let rec handle state = actor {
 }
 ```
 
-It is also possible to construct *workflow* actors that run a set number of steps instead of processing messages in a loop. For example:
+It is also possible to construct *workflow* actors that run a set number of steps instead of
+processing messages in a loop. For example:
 
 ```f#
 open WAkka.Simple
@@ -89,19 +123,42 @@ let workflow = actor {
 }
 ```
 
-This actor would wait for two messages, then send a message to another actor, and finally stop (reaching the end of the CE will cause the actor to stop).
+This actor would wait for two messages, then send a message to another actor, and finally stop (
+reaching the end of the CE will cause the actor to stop).
 
 ### Spawning Actors
-Actors are normally started using *spawn* functions defined in either the WAkka.Simple or WAkka.EventSourced modules. For specialized cases where an actor class is needed (e.g., remote deployment) please see Actor Classes [below](#alternate-spawning-via-actor-classes). The parent, properties, and action for the new actor are passed in. An `Akkling.ActorRefs.IActorRef<'Msg>` pointing at the new actor is returned. The `'Msg` type is inferred from the calling context. If you want to fix the message type in the actor reference then wrap your call to `spawn` in a function and specify the message type for the returned reference:
+
+Actors are normally started using the static methods of the *Spawn* class defined in either the
+`WAkka.Simple` or `WAkka.EventSourced` modules. For specialized cases where an actor class is needed
+(e.g., remote deployment) please see Actor Classes [below](#alternate-spawning-via-actor-classes).
+The parent,
+properties, and action for the new actor are passed in. An `Akkling.ActorRefs.IActorRef<'Msg>`
+pointing at the new actor is returned. The `'Msg` type is inferred from the calling context. If you
+want to fix the message type in the actor reference then wrap your call to spawn and actor in a
+function and specify the message type for the returned reference:
 
 ```f#
 open WAkka
 let startActor parent : IActorRef<string> = WAkka.Simple.spawnNotPersisted parent Context.Props.Anonymous action
 ```
 
-The properties are given using a `WAkka.Context.Props` object (`WAkka.EventSourced.Props` if the actor is persistent). For most actors, the defaults should be fine and the `Props.Anonymous` or `Props.Named` methods can be used to create an anonymous or named actor respectively. The members of `WAkka.Context.Props` are the same as what you would have when creating an actor in Akkling. So see that documentation if you need to change something from the defaults.
+The properties are given using a `WAkka.Context.Props` object (`WAkka.EventSourced.Props` if the
+actor is persistent). For most actors, the defaults should be fine and the `Props.Anonymous` or
+`Props.Named` methods can be used to create an anonymous or named actor respectively. The members of
+`WAkka.Context.Props` are the same as what you would have when creating an actor in Akkling. So see
+that documentation if you need to change something from the defaults.
 
-The actor type, which specifies how actor crashes are dealt with, is set by which *spawn* function is used. The simplest actor type is *not persisted*. They are started by `WAkka.Simple.spawnNotPersisted`, and if they crash then they will restart from the given action, no state is maintained across crashes. Next we have *checkpointed* actors which is started by using `WAkka.Simple.spawnCheckpointed`. These actors return to the last place a message was waited for in the event of a crash. This will restore the state to what it was before the most recent message was received. Note that this actor will only restore state across an actor restart, the state will not survive a process crash. To survive a process crash one needs to use either `WAkka.EventSourced.spawnNoSnapshots` or `WAkka.EventSourced.spawnSnapshots` which creates an actor that uses the Akka.NET persistence mechanisms (see Event Sourced Actions [below](#event-sourced-actions)).
+The actor type, which specifies how actor crashes are dealt with, is set by which *spawn*
+function is used. The simplest actor type is *not persisted*. They are started by `WAkka.Simple.
+spawnNotPersisted`, and if they crash then they will restart from the given action, no state is
+maintained across crashes. Next we have *checkpointed* actors which is started by using `WAkka.
+Simple.spawnCheckpointed`. In the event of a crash, these actors return to the last place that
+they waited for a message. This will restore the state to what it was before the most recent message
+was received. Note that this actor will only restore state across an actor restart, the state will
+not survive a process crash. To survive a process crash one needs to use either
+`WAkka.EventSourced.Spawn.NoSnapshots` or `WAkka.EventSourced.Spawn.WithSnapshots` which create an
+actor that uses the Akka.NET persistence mechanisms (see Event Sourced Actions [below]
+(#event-sourced-actions)).
 
 To start the two actors above one would do:
 
@@ -112,23 +169,43 @@ let act1 = Simple.spawnNotPersisted parent Context.Props.Anonymous (handle "")
 let act2 = Simple.spawnNotPersisted parent Context.Props.Anonymous workflow
 ```
 
-In this case the actors were started with no persistence. To use checkpointing just substitute `Simple.spawnCheckpointed` for `Simple.spawnNotPersisted`. 
+In this case the actors were started with no persistence. To use checkpointing just substitute
+`Simple.spawnCheckpointed` for `Simple.spawnNotPersisted`.
 
 #### Deprecated Spawn Functions
 
-Before version 1.5, WAkka spawned actors using the functions in the `WAkka.Spawn` module. Those functions still exist to support backwards compatibility, but should not be used in new code.
+Before version 1.5, WAkka spawned actors using the functions in the `WAkka.Spawn` or various
+functions in the `WAkka.Simple` and `WAkka.EventSourced` module. Those functions still exist to
+support backwards compatibility, but should not be used in new code. The static members of
+the `Spawn` class in each of those modules should be used instead.
 
 #### Alternate spawning via actor classes
 
-In most cases, starting actors using the `spawn*` functions as above should be sufficient. But in some cases (e.g., remote deployment), we need to implement the actor using a class derived from `Akka.Actor.ActorBase` so that we can put a type into `Akka.Actor.Props`. WAkka provides a way to do this via the `WAkka.Simple.NotPersistedActor`, `WAkka.Simple.CheckpointedActor`, `WAkka.EventSourced.EventSourcedActor` and `WAkka.EventSourced.EventSourcedSnapshotActor` classes that correspond to *not persisted*, *checkpointed*, *persistent (no snapshots)*, and *persistent (with snapshots)* actor types respectively. One derives a class from the appropriate base class for the type of actor wanted, passing the action to execute to the super-class constructor. This class can then be used anywhere one would use any other Akka actor class.
+In most cases, starting actors using the *spawn methods* shown above should be sufficient. But in
+some cases (e.g., remote deployment), we need to implement the actor using a class derived from
+`Akka.Actor.ActorBase` so that we can put a type into `Akka.Actor.Props`. WAkka provides a way to do
+this via the `WAkka.Simple.NotPersistedActor`, `WAkka.Simple.CheckpointedActor`,
+`WAkka.EventSourced.EventSourcedActor` and `WAkka.EventSourced.EventSourcedSnapshotActor` classes
+that correspond to *not persisted*, *checkpointed*, *persistent (no snapshots)*, and *persistent (
+with snapshots)* actor types respectively. One derives a class from the appropriate base class for
+the type of actor wanted, passing the action to execute to the super-class constructor. This class
+can then be used anywhere one would use any other Akka actor class.
 
-Note that if you are using this to do remote deployment or pooled routers in clusters then the usual rules apply. All of your constructor arguments must be serializable and the class must exist in each process where the actors are to be remotely deployed. WAkka actions are not serializable which is why you need to derive a class from one of the provided base classes instead of just using them directly and passing the action to their constructors when doing remote deployment. 
+Note that if you are using this to do remote deployment or pooled routers in clusters then the usual
+rules apply. All of your constructor arguments must be serializable and the class must exist in each
+process where the actors are to be remotely deployed. WAkka actions are not serializable which is
+why you need to derive a class from one of the provided base classes instead of just using them
+directly and passing the action to their constructors when doing remote deployment.
 
 ### Built-in actions
-Actor computation expressions are built using the actions built into WAkka. So far we've seen `Receive.Any`, `Receive.Only`, and `send` (in the guise of the `<!` operator) in the examples above. There are three classes of built-in actions:
+
+Actor computation expressions are built using the actions built into WAkka. So far we've seen
+`Receive.Any`, `Receive.Only`, and `send` (in the guise of the `<!` operator) in the examples above.
+There are three classes of built-in actions:
 
 * Common: Actions that can be used in any context.
-* Simple: Actions that can only be used in *simple* contexts (i.e., these cannot be directly used in CE's that define an event sourced actor).
+* Simple: Actions that can only be used in *simple* contexts (i.e., these cannot be directly used in
+  CE's that define an event sourced actor).
 * EventSourced: Actions that can only be used in an event sourced context.
 
 #### Common Actions
@@ -136,53 +213,92 @@ Actor computation expressions are built using the actions built into WAkka. So f
 These actions can be used directly in both simple and event sourced actors.
 
 * `getActor`: Get the reference for this actor.
-* `unsafeGetActorCtx`: Gets the actor context for this actor as a `WAkka.Context.IActorContext`. Normally this context is not needed, its functionality is available through the built-in actions.
-* `getLogger`: Gets an `WAkka.Logger.Logger` for this actor which can be used to log messages through the Akka.NET logging system.
+* `unsafeGetActorCtx`: Gets the actor context for this actor as a `WAkka.Context.IActorContext`.
+  Normally this context is not needed, its functionality is available through the built-in actions.
+* `getLogger`: Gets an `WAkka.Logger.Logger` for this actor which can be used to log messages
+  through the Akka.NET logging system.
 * `stop`: Stops this actor.
-* `createChild`: Creates a child of this actor. The given function will be passed an `IActorRefFactory` to use when creating the new actor.
-* `send`: Send the given message to the given actor. We also override the `<!` operator to do this (the Akkling version of this operator should not be used in an actor CE, it can cause unexpected behavior).
+* `createChild`: Creates a child of this actor. The given function will be passed an
+  `IActorRefFactory` to use when creating the new actor.
+* `send`: Send the given message to the given actor. We also override the `<!` operator to do this (
+  the Akkling version of this operator should not be used in an actor CE, it can cause unexpected
+  behavior).
 * `watch`: Have this actor watch the given actor for termination.
 * `unwatch`: Stop watching the given actor for termination.
-* `schedule`: Schedule the given message to be sent to the given actor after the given delay. Returns an object that can be used to cancel the sending of the message.
-* `scheduleRepeatedly`: Similar to `schedule`, but after the first send, the message will be sent repeatedly with the given interval between sends.
+* `schedule`: Schedule the given message to be sent to the given actor after the given delay.
+  Returns an object that can be used to cancel the sending of the message.
+* `scheduleRepeatedly`: Similar to `schedule`, but after the first send, the message will be sent
+  repeatedly with the given interval between sends.
 * `select`: Get an actor selection for the given path.
 * `selectPath`: Get an actor selection for the given path.
-* `setRestartHandler`: Sets a function to be called if the actor restarts. The function will be passed the actor context, message that was being processed when the crash happened, and the exception. The action returns an ID that can be used to remove the handler via the `clearRestartHandler` action. 
-* `clearRestartHandler`: Clears any restart handler that was set using the `setRestartHandler` action.
-* `setStopHandler`: Sets a function to be called if the actor stops. The function will be passed the actor context. The action returns an ID that can be used to remove the handler via the `clearStopHandler` action. 
+* `setRestartHandler`: Sets a function to be called if the actor restarts. The function will be
+  passed the actor context, message that was being processed when the crash happened, and the
+  exception. The action returns an ID that can be used to remove the handler via the
+  `clearRestartHandler` action.
+* `clearRestartHandler`: Clears any restart handler that was set using the `setRestartHandler`
+  action.
+* `setStopHandler`: Sets a function to be called if the actor stops. The function will be passed the
+  actor context. The action returns an ID that can be used to remove the handler via the
+  `clearStopHandler` action.
 * `clearStopHandler`: Clears any stop handler that was set using the `setStopHandler` action.
-* `getContext`: Gets an `IContext` object that allows access to the functionality of the above actions. This is mostly meant to be used with `HandleMessages` action (see [below](#handlemessages)).
+* `getContext`: Gets an `IContext` object that allows access to the functionality of the above
+  actions. This is mostly meant to be used with `HandleMessages` action (
+  see [below](#handlemessages)).
 
 The `Common` module also contains functions to change the result type of an action:
-* `ignoreResult`: Ignore the result of a given action, makes things behave as though the result of the action is `unit`.
-* `mapResult`: Apply a given function to the result of an action. Changes an action's result type to that of the function.
+
+* `ignoreResult`: Ignore the result of a given action, makes things behave as though the result of
+  the action is `unit`.
+* `mapResult`: Apply a given function to the result of an action. Changes an action's result type to
+  that of the function.
 
 #### Simple actions
 
-These actions can only be used directly in a simple actor (i.e. those started with `Simple.spawnNotPersisted` or `Simple.spawnCheckpointed`)
+These actions can only be used directly in a simple actor (i.e. those started with
+`Simple.spawnNotPersisted` or `Simple.spawnCheckpointed`)
 
-* `Receive`: Static methods of this class are used to receive messages. Each method has an optional timeout and those that filter messages have a *strategy* for dealing with messages that are filtered out. You can make custom *other message strategies*, but the most useful are already provided in `ignoreOthers` and `stashOthers`. `ignoreOthers`, which is the default, will ignore any messages that are filtered out. `stashOthers` will stash messages that are filtered out, and then unstash them when a message satisfies the filter.
-  * `Any`: Receive the next message (no filtering).
-  * `Filter`: Receive messages until one is received that satisfies the given filter.
-  * `Only<'Type>`: Receives messages until one of type `'Type` is received.
-  * `HandleMessages`: Switches to processing messages with a message handling function, see [below](#handlemessages).
+* `Receive`: Static methods of this class are used to receive messages. Each method has an optional
+  timeout and those that filter messages have a *strategy* for dealing with messages that are
+  filtered out. You can make custom *other message strategies*, but the most useful are already
+  provided in `ignoreOthers` and `stashOthers`. `ignoreOthers`, which is the default, will ignore
+  any messages that are filtered out. `stashOthers` will stash messages that are filtered out, and
+  then unstash them when a message satisfies the filter.
+    * `Any`: Receive the next message (no filtering).
+    * `Filter`: Receive messages until one is received that satisfies the given filter.
+    * `Only<'Type>`: Receives messages until one of type `'Type` is received.
+    * `HandleMessages`: Switches to processing messages with a message handling function,
+      see [below](#handlemessages).
 * `getSender`: Gets the sender of the most recently received message.
-* `sleep`: Applies the given *other messages strategy* to any messages received for the given amount of time. 
+* `sleep`: Applies the given *other messages strategy* to any messages received for the given amount
+  of time.
 * `stash`: Stashes the most recently received message.
 * `unstashOne`: Unstashes the message at the front of the stash.
 * `unstashAll`: Unstashes all stashed messages.
 
 There are also functions for doing maps and folds of actions:
 
-* `mapArray`: Applies a function whose result is an action and applies it an array of values generating an action that evaluates each of the generated actions capturing their results in an array which become the result of the action.
+* `mapArray`: Applies a function whose result is an action and applies it an array of values
+  generating an action that evaluates each of the generated actions capturing their results in an
+  array which become the result of the action.
 * `mapList`: Same as `mapArray`, but works with lists instead of arrays.
-* `foldActions`: takes an initial value of type `'res`, a sequence of actions of type `'a`, and function `'res -> 'a -> Action<'res>`. Creates an action that evaluates the first action from the sequence, passes its result and the initial value to the function and evaluates the resulting action. The result of this action becomes the `'res` value that is combined with the result of the next action from the sequence using the function. This continues until the sequence of actions is exhausted, at which point the final `'res` value is the result of the action.
-* `foldValues`: Works similar to `foldActions`, except that an sequence of values is passed in instead of an array of actions and the values in the sequence are used directly in when evaluating the function to generate sub-actions.
-* `executeWhile`: Executes a *condition* action, if it returns `Some` then the result is passed to the body function and the resulting action executed. Repeats until the condition action evaluates to `None`.
+* `foldActions`: takes an initial value of type `'res`, a sequence of actions of type `'a`, and
+  function `'res -> 'a -> Action<'res>`. Creates an action that evaluates the first action from the
+  sequence, passes its result and the initial value to the function and evaluates the resulting
+  action. The result of this action becomes the `'res` value that is combined with the result of the
+  next action from the sequence using the function. This continues until the sequence of actions is
+  exhausted, at which point the final `'res` value is the result of the action.
+* `foldValues`: Works similar to `foldActions`, except that a sequence of values is passed in
+  instead of an array of actions and the values in the sequence are used directly in when evaluating
+  the function to generate sub-actions.
+* `executeWhile`: Executes a *condition* action, if it returns `Some` then the result is passed to
+  the body function and the resulting action executed. Repeats until the condition action evaluates
+  to `None`.
 
 ##### HandleMessages
 
-Many actors just need to be able to handle a given message type in a loop, possibly updating some state. That can be accomplished using the `actor` computation expression:
+Many actors just need to be able to handle a given message type in a loop, possibly updating some
+state. That can be accomplished using the `actor` computation expression:
+
 ```f#
 let rec handle state = actor {
     match! Receive.Any() with 
@@ -196,13 +312,20 @@ let rec handle state = actor {
 spawn parent Props.Anonymous (notPersistent (handle initState))
 ```
 
-This pattern comes up enough that we provide a special action for it: `HandleMessages`, which takes a message handling function that will be called for each message received. The message handling function returns one of the cases of `HandleMessagesResult`:
-* `IsDone result`: Stops message handling and returns control to where `HandleMessages` was called, causing the `HandleMessages` action to evaluate to `result`. If this was a call to a *spawn* function, then the actor will exit.
+This pattern comes up enough that we provide a special action for it: `HandleMessages`, which takes
+a message handling function that will be called for each message received. The message handling
+function returns one of the cases of `HandleMessagesResult`:
+
+* `IsDone result`: Stops message handling and returns control to where `HandleMessages` was called,
+  causing the `HandleMessages` action to evaluate to `result`. If this was a call to a *spawn*
+  function, then the actor will exit.
 * `Continue`: Continue to process messages with the same message handler.
 * `ContinueWith handler`: Continue to process messages using the given handler.
-* `ContinueWithAction action`: Run the given action. When the action finishes, its result will be the result of the `HandleMessages` action.
+* `ContinueWithAction action`: Run the given action. When the action finishes, its result will be
+  the result of the `HandleMessages` action.
 
 The above can be written as:
+
 ```f#
 let rec handle state msg = 
         match msg with
@@ -216,7 +339,15 @@ let rec handle state msg =
 }
 Simple.spawnNotPersisted parent Props.Anonymous (Receive.HandleMessages (handle initState))
 ```
-This isn't terribly different than the original code, but has a few advantages. The message handling is not inside of a computation expression, so if the need arises to run it under a debugger, you will have a much easier time. The second example will also execute faster since it bypasses all the computation expression machinery (and it's concomitant memory allocations). For most actors the computation expression is probably fast enough, but if you want parity with either Akkling or Akka then using `HandleMessages` is called for. In fact, once can attain parity with the Akka `UntypedActor` with mutable state by making a change to the above example:
+
+This isn't terribly different from the original code, but has a few advantages. The message handling
+is not inside a computation expression, so if the need arises to run it under a debugger, you
+will have a much easier time. The second example will also execute faster since it bypasses all the
+computation expression machinery (and it's concomitant memory allocations). For most actors the
+computation expression is probably fast enough, but if you want parity with either Akkling or Akka
+then using `HandleMessages` is called for. In fact, once can attain parity with the Akka
+`UntypedActor` with mutable state by making a change to the above example:
+
 ```f#
 let mutable state = initState
 let rec handle msg = 
@@ -234,27 +365,68 @@ let rec handle msg =
 Simple.spawnNotPersistent parent Props.Anonymous (Receive.HandleMessages handle)
 ```
 
-This example will not allocate any memory in the course of processing messages. It sacrifices *functional purity* since it uses mutable state, but if you need the absolute best possible performance, it's not uncommon to have to make that sacrifice on a small scale in order to get it. 
+This example will not allocate any memory in the course of processing messages. It sacrifices
+*functional purity* since it uses mutable state, but if you need the absolute best possible
+performance, it's not uncommon to have to make that sacrifice on a small scale in order to get it.
 
-Note that `HandleMessages` expects a function with signature `'Msg -> HandleMessagesResult<'Msg, 'Result>`. While the message handler is processing messages, any messages that are not of type `'Msg` will be ignored. If you want to receive all messages then your `'Msg` type must be `obj`. 
+Note that `HandleMessages` expects a function with signature
+`'Msg -> HandleMessagesResult<'Msg, 'Result>`. While the message handler is processing messages, any
+messages that are not of type `'Msg` will be ignored. If you want to receive all messages then your
+`'Msg` type must be `obj`.
 
-`HandleMessages` can be mixed in with computation expression code as well. Since `HandleMessages` is an action, it can be called as 
+`HandleMessages` can be mixed in with computation expression code as well. Since `HandleMessages` is
+an action, it can be called as
+
 ```f#
 actor {
     let! result = Receive.HandleMessages handle
     ... // Do stuff with result
 ```
-In this code, the `handle` function will be called to handle each message that is received until it evaluates to `HandleMessagesResult.IsDone value`. `value` will then be the result of the `HandleMessages` action and `result` will be bound to it. One can also transition from a message handling function to a computation expression by having the message handling function evaluate to `HandleMessageResult.ContinueWithAction action` where `action` is the action that you want to execute. Note that if you want to go back to your message handling function at some point, then you will need to explicitly do a `return! Receive.HandleMessages handle` inside of your action (here `handle` is the message handling function to return to). 
 
-There is often a need to access the functionality that is contained in other action types when in the message handling function of `HandleMessages`. Unfortunately, actions cannot be used in the message handler, except by returning `ContinueWithAction` and the action then doing `return! HandleMessages ...`. This is very cumbersome. One option would to call the `getContext` action before calling `HandleMessages` and capture the `IContext` object in your message handler, then accessing the desired functionality through the captured object. This is a common enough pattern that there is a second version of `HandleMessages` that does it for you. Just pass a message handler with signature `IContext -> 'Msg -> HandleMessagesResult<'Msg, 'Result>` instead of `'Msg -> HandleMessagesResult<'Msg, 'Result>` and the context will be passed to your handler. Note that the context is only passed to the initial handler, if you do `ContinueWith handler` then `handler` must have signature `'Msg -> HandleMessagesResult<'Msg, 'Result>`, so it is up to you to propagate the context to the new handler if it is needed.
+In this code, the `handle` function will be called to handle each message that is received until it
+evaluates to `HandleMessagesResult.IsDone value`. `value` will then be the result of the
+`HandleMessages` action and `result` will be bound to it. One can also transition from a message
+handling function to a computation expression by having the message handling function evaluate to
+`HandleMessageResult.ContinueWithAction action` where `action` is the action that you want to
+execute. Note that if you want to go back to your message handling function at some point, then you
+will need to explicitly do a `return! Receive.HandleMessages handle` inside of your action (here
+`handle` is the message handling function to return to).
 
-So when should you use the `actor` computation expression versus `HandleMessages`? If your actor does the same thing for every message that it receives then `HandleMessages` is probably the way to go. It's easier to trace through in the debugger and you'll get better performance (again, unless you're pushing the limits of processor power, the computation expression approach probably has plenty of performance for you). If you're running *workflow* style code then the computation expression is what you want since it is much more versatile. You can also mix them as we saw above. You could use `HandleMessages`, and when certain messages are received, use `ContinueWithAction` to launch into a workflow, returning to the original message handler via `return! HandleMessages ...` when the workflow is done. 
+There is often a need to access the functionality that is contained in other action types when in
+the message handling function of `HandleMessages`. Unfortunately, actions cannot be used in the
+message handler, except by returning `ContinueWithAction` and the action then doing
+`return! HandleMessages ...`. This is very cumbersome. One option would to call the `getContext`
+action before calling `HandleMessages` and capture the `IContext` object in your message handler,
+then accessing the desired functionality through the captured object. This is a common enough
+pattern that there is a second version of `HandleMessages` that does it for you. Just pass a message
+handler with signature `IContext -> 'Msg -> HandleMessagesResult<'Msg, 'Result>` instead of
+`'Msg -> HandleMessagesResult<'Msg, 'Result>` and the context will be passed to your handler. Note
+that the context is only passed to the initial handler, if you do `ContinueWith handler` then
+`handler` must have signature `'Msg -> HandleMessagesResult<'Msg, 'Result>`, so it is up to you to
+propagate the context to the new handler if it is needed.
+
+So when should you use the `actor` computation expression versus `HandleMessages`? If your actor
+does the same thing for every message that it receives then `HandleMessages` is probably the way to
+go. It's easier to trace through in the debugger, and you'll get better performance (again, unless
+you're pushing the limits of processor power, the computation expression approach probably has
+plenty of performance for you). If you're running *workflow* style code then the computation
+expression is what you want since it is much more versatile. You can also mix them as we saw above.
+You could use `HandleMessages`, and when certain messages are received, use `ContinueWithAction` to
+launch into a workflow, returning to the original message handler via `return! HandleMessages ...`
+when the workflow is done.
 
 #### Actor Result
 
-It is sometimes useful to have actions that evaluate to the `Result` type. The `ActorResult` module defines a computation expression that combines these two types. I.e., the CE will execute actions until it runs out or an action evaluates to `Error`. The result of the CE is `Ok <value>` if it makes it to the end without getting an `Error`. `<value>` will be the return value of the CE. If an `Error` is encountered then the CE's value will be that error. Note that all elements in the CE must have the same `Error` type, but their `Ok` types can differ.
+It is sometimes useful to have actions that evaluate to the `Result` type. The `ActorResult` module
+defines a computation expression that combines these two types. I.e., the CE will execute actions
+until it runs out or an action evaluates to `Error`. The result of the CE is `Ok <value>` if it
+makes it to the end without getting an `Error`. `<value>` will be the return value of the CE. If an
+`Error` is encountered then the CE's value will be that error. Note that all elements in the CE must
+have the same `Error` type, but their `Ok` types can differ.
 
-The `actorResult` builder is used to build an actor result CE and it is run by passing it to `runActorResult`. For example:
+The `actorResult` builder is used to build an actor result CE. To run the resulting action, pass it
+to `runActorResult`. For example:
+
 ```f#
 let act = actor {
     return! runActorResult (actorResult{
@@ -263,27 +435,46 @@ let act = actor {
     })
 }
 ```
-would wait for a message of type `Result<string, string>`. If it receives `Ok <message>` then the result of running `act` would be `Ok "message was <message>"` since the `return $message...` line would be executed. But if the message received was `Error <error>` then the `return ...` line would be skipped and the result of `act` would be `Error err`. 
+
+would wait for a message of type `Result<string, string>`. If it receives `Ok <message>` then the
+result of running `act` would be `Ok "message was <message>"` since the `return $message...` line
+would be executed. But if the message received was `Error <error>` then the `return ...` line would
+be skipped and the result of `act` would be `Error err`.
 
 The `ActorResult` module contains more functions to make working with this CE easier:
 
 * `retn`, `ok`: Wrap the given value so that it evaluates to `Ok <value>`.
 * `returnError`, `error`: Wrap the given value so that is evaluates to `Error <value>`.
-* `map`: Applies the given function to the value of an action if that action evaluates to `Ok`. The result of the function is wrapped in `Ok`.
+* `map`: Applies the given function to the value of an action if that action evaluates to `Ok`. The
+  result of the function is wrapped in `Ok`.
 * `mapError`: Similar to `map`, but acts on `Error` instead of `Ok`.
-* `orElse`: Evaluates an action, then evaluates another action if the first action evaluates to `Error`. Designed to be chained using the `|>` operator: `action1 |> orElse action2 |> orElse action3...`.
-* `orElseWith`: Similar to `orElse`, but the action to evaluate in the error case is generated by a function that is passed the error value.
-* `ignore`: Ignores the `Ok` part fo a result converting it from `ActorResult<'a, 'e>` to `ActorResult<unit, 'e>`.
-* `require*`: Many functions for converting other types, like booleans, `Option`, etc. to `ActorResult`. They all start with `require`.
+* `orElse`: Evaluates an action, then evaluates another action if the first action evaluates to
+  `Error`. Designed to be chained using the `|>` operator:
+  `action1 |> orElse action2 |> orElse action3...`.
+* `orElseWith`: Similar to `orElse`, but the action to evaluate in the error case is generated by a
+  function that is passed the error value.
+* `ignore`: Ignores the `Ok` part fo a result converting it from `ActorResult<'a, 'e>` to
+  `ActorResult<unit, 'e>`.
+* `require*`: Many functions for converting other types, like booleans, `Option`, etc. to
+  `ActorResult`. They all start with `require`.
 * `ofActor`: Runs the given actor action and wraps the result in `Ok`.
 * `ofResult`: Converts a `Result` to an `ActorResult` that evaluates to the original result.
 
 #### Event sourced actions
 
-The Akka persistence system is accessed via actions defined in the `EventSourced`  module. These actions can only be used in an *event sourced* actor (i.e. those started using `EventSourced.spawnNoSnapshots` or `EventSourced.spawnSnapshots`).
+The Akka persistence system is accessed via actions defined in the `EventSourced`  module. These
+actions can only be used in an *event sourced* actor (i.e. those started using `EventSourced.
+Spawn.NoSnapshots` or `EventSourced.Spawn.WithSnapshots`).
 
-* `persist`: Run the given simple action and persist the result. When the actor is recovering from a crash the simple action is skipped and the persisted result is returned. The result of `persist` is a `PersistResult` which is either the result of the action, or a lifecycle event (recovery finished, recovery failed, or the result of the simple action was rejected by the persistence system).
-* `persistSimple`: Run the given simple action and persist the result. When the actor is recovering from a crash the simple action is skipped and the persisted result is returned. Just the result of the simple action is returned, persistence lifecycle events are filtered out. If an action result is rejected by the persistence system or recovery fails then the actor will be stopped.
+* `persist`: Run the given simple action and persist the result. When the actor is recovering from a
+  crash the simple action is skipped and the persisted result is returned. The result of `persist`
+  is a `PersistResult` which is either the result of the action, or a lifecycle event (recovery
+  finished, recovery failed, or the result of the simple action was rejected by the persistence
+  system).
+* `persistSimple`: Run the given simple action and persist the result. When the actor is recovering
+  from a crash the simple action is skipped and the persisted result is returned. Just the result of
+  the simple action is returned, persistence lifecycle events are filtered out. If an action result
+  is rejected by the persistence system or recovery fails then the actor will be stopped.
 * `isRecovering`: Gets whether the actor is currently recovering or not.
 
 To make the stateful example above work as an event sourced actor we would do:
@@ -304,26 +495,72 @@ let rec handle state = EventSourced.actor {
     return! handle newState
 }
     
-let act = EventSourced.spawnNoSnapshots parent EventSourced.Props.Anonymous (handle "")
+let act = EventSourced.Spawn.NoSnapshots(parent, EventSourced.Props.Anonymous, (fun () -> handle ""))
 ```
 
-This actor runs the `handleMsg` action in a simple context. It looks for a `string` message. When one is received, the simple action finishes with that string message as its result. The `persist` action that `handleMsg` was running in then persists this message and returns it. `handle` then recurses with the new state. If the actor were to crash then all the calls to `persistSimple` would skip calling `handleMsg` and return the persisted results instead. Once the persisted results are exhausted, `persistSimple` will begin calling `handleMsg` again. 
+This actor runs the `handleMsg` action in a simple context. It looks for a `string` message. When
+one is received, the simple action finishes with that string message as its result. The
+`persistSimple` action that `handleMsg` was running in then persists this message and returns it.
+`handle` then recurses with the new state. If the actor were to crash then all the calls to
+`persistSimple` would skip calling `handleMsg` and return the persisted results instead. Once the
+persisted results are exhausted, `persistSimple` will begin calling `handleMsg` again.
 
-Note that in order to have event sourced actor state survive a process restart, you will have to configure a persistence back-end when starting the actor system. That is beyond the scope of this document.
+Note that in order to have event sourced actor state survive a process restart, you will have to
+configure a persistence back-end when starting the actor system. That is beyond the scope of this
+document.
 
 ##### Persistence Ids
 
-By default, the actor path will be used as the persistence id presented to the Akka persistence system. If this is not desired, then the `persistenceId` member of `EventSourced.Props` should be set (`EventSourced.Props.PersistenceId` provides a shortcut to set this and the actor name).
+By default, the actor path will be used as the persistence id presented to the Akka persistence
+system. If this is not desired, then the `persistenceId` member of `EventSourced.Props` should be
+set (`EventSourced.Props.PersistenceId` provides a shortcut to set this and the actor name).
 
 ##### Snapshots
 
-If an actor is started with `EventSourced.spawnSnapshots` then it will support persistence snapshots. The difference from `EventSourced.spawnNoSnapshots` is that in addition to passing in an initial action for the actor to execute, a function to handle a snapshot is also passed in. If no snapshot is available, then the initial action is executed. If a snapshot is available, then it is passed to the snapshot handler function which returns the action to execute instead of the initial action.
+If an actor is started with `EventSourced.Spawn.WithSnapshots` then it will support persistence
+snapshots. The difference from `EventSourced.Spawn.NoSnapshots` is that the function that generates
+the initial action for the actor to execute will be passed an optional snapshot (`Some` if a
+snapshot is available, `None` otherwise).
 
-Snapshots are managed using the following actions (which can only be used if the actor is started using `spawnSnapshots`):
+Snapshots are managed using the following actions (which can only be used if the actor is
+started using `WithSnapshots`):
+
 * `getLastSequenceNumber`: Gets the sequence number of the last event that was persisted.
-* `saveSnapshot`: Saves the given snapshot. Note that snapshots are typed, and all saved snapshots for a given actor must be the same type. `obj` is a valid snapshot type if you need that amount of flexibility in your snapshots. If you need to track that a snapshot succeeded then watch for `Akka.Persistence.SaveSnapshotSuccess` and/or `Akka.Persistence.SaveSnapshotFailure` messages.
-* `deleteEvents`: Delete persisted events up to the given sequence number. This should only be done after saving a snapshot (preferably after receiving a `Akka.Persistence.SaveSnapshotSuccess` since snapshots are saved asynchronously). If you need to track success then watch for `Akka.Persistence.DeleteMessagesSuccess` and/or `Akka.Persistence.DeleteMessagesFailure` messages.
-* `deleteSnapshot`: Delete the snapshot with the given sequence number. If you need to track success then watch for `Akka.Persistence.DeleteSnapshotSuccess` and/or `Akka.Persistence.DeleteSnapshotFailure` messages.
-* `deleteSnapshots`: Delete snapshots that match the given `Akka.Persistence.SnapshotSelectionCriteria`. If you need to track success then watch for `Akka.Persistence.DeleteSnapshotsSuccess` and/or `Akka.Persistence.DeleteSnapshotsFailure` messages.
+* `saveSnapshot`: Saves the given snapshot. Note that snapshots are typed, and all saved snapshots
+  for a given actor must be the same type. `obj` is a valid snapshot type if you need that amount of
+  flexibility in your snapshots. If you need to track that a snapshot succeeded then watch for
+  `Akka.Persistence.SaveSnapshotSuccess` and/or `Akka.Persistence.SaveSnapshotFailure` messages.
+* `deleteEvents`: Delete persisted events up to the given sequence number. This should only be done
+  after saving a snapshot (preferably after receiving a `Akka.Persistence.SaveSnapshotSuccess` since
+  snapshots are saved asynchronously). If you need to track success then watch for
+  `Akka.Persistence.DeleteMessagesSuccess` and/or `Akka.Persistence.DeleteMessagesFailure` messages.
+* `deleteSnapshot`: Delete the snapshot with the given sequence number. If you need to track success
+  then watch for `Akka.Persistence.DeleteSnapshotSuccess` and/or
+  `Akka.Persistence.DeleteSnapshotFailure` messages.
+* `deleteSnapshots`: Delete snapshots that match the given
+  `Akka.Persistence.SnapshotSelectionCriteria`. If you need to track success then watch for
+  `Akka.Persistence.DeleteSnapshotsSuccess` and/or `Akka.Persistence.DeleteSnapshotsFailure`
+  messages.
+* `addSnapshotResultHandler`: Registers a function that will be called with the result of a
+  snapshot save (either success or failure). The function is also passed an
+  `IPersistenceControl` that allows the function to delete events or snapshots. If the function
+  returns `false` then the actor will be stopped. The result of `addSnapshotResultHandler` is an
+  index that can be pass to `removeSnapshotResultHandler` to unregister the function. For
+  convenience, a snapshot result handler that can either delete events and/or prior snapshots on
+  snapshot success is provided in `SnapshotResultHandler`. Note that the snapshot result messages
+  from Akka.NET are still delivered to the actor as well.
+* `removeSnapshotResultHandler`: Removes a snapshot result handler registered with
+  `addSnapshotResultHandler`.
 
-Note that if you have an actor that is started using `Spawn.eventSourced`, then it is the equivalent of being started with `spawnNoSnapshots` and it will not be able to use snapshots. To upgrade it to an actor that can use snapshots, you will have to change your code to use `spawnSnapshots` when starting the actor. 
+Note that if you have an actor that is started using `WAkka.Spawn.eventSourced` or `WAkka.
+EventSourced.spawnNoSnapshots`, then it is the equivalent of being started with
+`WAkka.EventSourced.Spawn.NoSnapshots` and it will not be able to use snapshots.
+`WAkka.EventSourced.spawnSnapshots` is the equivalent of using
+`WAkka. EventSourced.Spawn.WithSnapshots` except that the initial actions to use when there is or is
+not a snapshot available are passed separately. It is suggested to use the methods of
+`WAkka. EventSourced.Spawn` instead of the individual functions which are provided for backwards
+compatibility.
+
+There are also the classes `EventSourced.EventSourcedActor` and `EventSourced.
+EventSourcedSnapshotActor` that can be used to start event sourced actors in cases where a class
+type is needed (e.g., remote deployment). 

--- a/readme.md
+++ b/readme.md
@@ -75,8 +75,8 @@ see [below](#handlemessages)).
 ## Usage
 
 WAkka is built on top of Akka.NET and Akkling. It uses the typed actor references from Akkling, and
-the general infrastructure from Akka.NET. The actor system should be started as though you're using
-Akkling. Then, the creation of actors should be done as shown below.
+the general infrastructure from Akka.NET. The actor system can be started in any of the usual ways,
+including the use of Akka.Hosting. Then, the creation of actors should be done as shown below.
 
 Note that the Akkling `<!` (*tell* operator) can cause unexpected behavior in WAkka computation
 expressions. In order to avoid this, WAkka also overrides this operator to behave properly in

--- a/readme.md
+++ b/readme.md
@@ -280,7 +280,7 @@ The `ActorResult` module contains more functions to make working with this CE ea
 
 #### Event sourced actions
 
-The Akka persistence system is accessed via actions defined in the `EventSourced`  module. These actions can only be used in an *event sourced* actor (i.e. those started using `EventSourced.spawnspawnNoSnapshots` or `EventSourced.spawnSnapshots`).
+The Akka persistence system is accessed via actions defined in the `EventSourced`  module. These actions can only be used in an *event sourced* actor (i.e. those started using `EventSourced.spawnNoSnapshots` or `EventSourced.spawnSnapshots`).
 
 * `persist`: Run the given simple action and persist the result. When the actor is recovering from a crash the simple action is skipped and the persisted result is returned. The result of `persist` is a `PersistResult` which is either the result of the action, or a lifecycle event (recovery finished, recovery failed, or the result of the simple action was rejected by the persistence system).
 * `persistSimple`: Run the given simple action and persist the result. When the actor is recovering from a crash the simple action is skipped and the persisted result is returned. Just the result of the simple action is returned, persistence lifecycle events are filtered out. If an action result is rejected by the persistence system or recovery fails then the actor will be stopped.


### PR DESCRIPTION
- Added "snapshot result handlers" (callbacks that are called when a snapshot result is received).
- Made the underlying Akka logger (which has more functionality than the WAkka logging interface) more generally available through the `getAkkaLogger` action and the `Logger` member of `WAkka.Common.Logger`. 
- Added new `WAkka.Simple.Spawn` with static methods for spawning that better mirror those added for event sourced actors.
- Clarified in the documentation that the actor system can be started in any of the usual ways, not only using the Akkling startup functions.