### PR TITLE
Allow deletion of events in non-snapshot actors

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ on:
       - '**.fsproj'
 
 env:
-  DOTNET_VERSION: '8.0.100' # The .NET SDK version to use
+  DOTNET_VERSION: '9.0.302' # The .NET SDK version to use
 
 jobs:
   build-and-test:

--- a/PerformanceTest/PerformanceTest.fsproj
+++ b/PerformanceTest/PerformanceTest.fsproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/WAkka/WAkkaTests/WAkkaTests.fsproj
+++ b/WAkka/WAkkaTests/WAkkaTests.fsproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <TargetFramework>net9.0</TargetFramework>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/WAkka/Wakka/ActorResult.fs
+++ b/WAkka/Wakka/ActorResult.fs
@@ -103,7 +103,7 @@ module ActorResult =
     ///     AsyncResult.ok "First" |> AsyncResult.orElseWith (fun _ -> AsyncResult.error "Second") // evaluates to Ok ("First")
     ///     AsyncResult.ok "First" |> AsyncResult.orElseWith (fun _ -> AsyncResult.ok "Second") // evaluates to Ok ("First")
     /// </code>
-    /// </example>
+    /// </example>1
     /// <returns>
     /// The result if the result is Ok, else the result of executing <paramref name="ifErrorFunc"/>.
     /// </returns>

--- a/WAkka/Wakka/Common.fs
+++ b/WAkka/Wakka/Common.fs
@@ -183,13 +183,13 @@ module CommonActions =
     
     /// Stops this actor.
     let stop () =
-        // This weird dance is here so that the result of stop can adapt to the context that it is called in, and
+        // This dance is here so that the result of stop can adapt to the context that it is called in, and
         // we don't have to do "do! stop (); return! something" and instead just do "return! stop ()" when an
         // Action<'Result, 'a> is expected and 'Result is not unit.
         bindBase (fun () -> Done Unchecked.defaultof<'Result>) (Stop Done)
 
     /// Creates a child of this actor. The given function will be passed an IActorRefFactory to use as the parent for
-    /// the child actor and the function's result will be the result of the action.
+    /// the child actor, and the function's result will be the result of the action.
     let createChild (make: Akka.Actor.IActorRefFactory -> 'Result) =
         Simple (fun ctx -> Done (make ctx.ActorFactory))
 

--- a/WAkka/Wakka/EventSourced.fs
+++ b/WAkka/Wakka/EventSourced.fs
@@ -74,7 +74,7 @@ type EventSourcedExtra<'Snapshot> =
     | AddSnapshotResultHandler of handler:(ISnapshotControl * SnapshotResult -> bool)
     | RemoveSnapshotResultHandler of index:int
     
-/// An action that can only be used directly in an event sourced actor (e.g. started using eventSourced).
+/// An action that can only be used directly in an event-sourced actor (e.g., started using eventSourced).
 type EventSourcedActionBase<'Result, 'Snapshot> = ActionBase<'Result, EventSourcedExtra<'Snapshot>>
 type NoSnapshotsAction<'Result> = EventSourcedActionBase<'Result, NoSnapshotExtra>
 type SnapshotAction<'Result, 'Snapshot> = EventSourcedActionBase<'Result, SnapshotExtra<'Snapshot>>
@@ -319,7 +319,7 @@ type private NoSnapshotHandler (startAction) =
 /// <summary>
 /// Class that can be used to spawn eventSourced actors that do not support snapshots. Usually, Spawn.NoSnapshots should
 /// be used to spawn this type of actor, but if you need a class type to use with Akka.Actor.Props.Create for special 
-/// cases (like remote deployment) then a new class can be derived from this class instead.  
+/// cases (like remote deployment), then a new class can be derived from this class instead.  
 /// </summary>
 /// <param name="startAction">The action for the actor to run.</param>
 /// <param name="persistenceId">The persistence id to use. If not given, the actor path will be used.</param>
@@ -352,7 +352,7 @@ type private SnapshotHandler<'Snapshot> (snapshotHandler) =
 /// <summary>
 /// Class that can be used to spawn event sourced actors. Usually, Spawn.WithSnapshots should be used to spawn this type
 /// of actor, but if you need a class type to use with Akka.Actor.Props.Create for special cases (like remote
-/// deployment) then a new class can be derived from this class instead.  
+/// deployment), then a new class can be derived from this class instead.  
 /// </summary>
 /// <param name="action">
 /// Function that generates the initial action for the actor. The function will be passed a persistence snapshot if
@@ -383,10 +383,10 @@ type EventSourcedSnapshotActor<'Snapshot>(
         EventSourcedSnapshotActor(handler, ?persistenceId = persistenceId)
     
 /// <summary>
-/// The properties for an event sourced actor.
+/// The properties for an event-sourced actor.
 /// </summary>
 type EventSourcedProps = {
-    /// The persistence id for the actor. If None then the actor's path will be used.
+    /// The persistence id for the actor. If None, then the actor's path will be used.
     persistenceId: Option<string>
     /// The common properties for the actor.
     common: Props
@@ -425,7 +425,7 @@ with
 type Spawn =
     
     /// <summary>
-    /// Spawns an event sourced actor. This variant does not support snapshots.
+    /// Spawns an event-sourced actor. This variant does not support snapshots.
     /// </summary>
     /// <param name="parent">The actor's parent.</param>
     /// <param name="props">The actor's properties.</param>
@@ -446,7 +446,7 @@ type Spawn =
         Akkling.ActorRefs.typed act
         
     /// <summary>
-    /// Spawns an event sourced actor. This variant supports snapshots.
+    /// Spawns an event-sourced actor. This variant supports snapshots.
     /// </summary>
     /// <param name="parent">The actor's parent.</param>
     /// <param name="props">The actor's properties.</param>
@@ -477,7 +477,7 @@ type Spawn =
         Akkling.ActorRefs.typed act
 
 /// <summary>
-/// Spawns an event sourced actor. This variant does not support snapshots. This exists for backwards compatibility, use
+/// Spawns an event-sourced actor. This variant does not support snapshots. This exists for backwards compatibility, use
 /// Spawn.NoSnapshots instead.
 /// </summary>
 /// <param name="parent">The parent for the new actor.</param>
@@ -487,7 +487,7 @@ let spawnNoSnapshots (parent: Akka.Actor.IActorRefFactory) (props: EventSourcedP
     Spawn.NoSnapshots (parent, props, (fun () -> action))
 
 /// <summary>
-/// Spawns an event sourced actor. This variant supports snapshots. This exists for backwards compatibility, use
+/// Spawns an event-sourced actor. This variant supports snapshots. This exists for backwards compatibility, use
 /// Spawn.WithSnapshots instead.
 /// </summary>
 /// <param name="parent">The parent for the new actor.</param>
@@ -521,7 +521,7 @@ module Actions =
         | ActionResult of 'Result
         /// The action was executed, but the result was rejected for the given reason by the persistence system.
         | ActionResultRejected of result:'Result * reason:exn * sequenceNr:int64
-        /// Recovery was running, but has now finished. The action was not executed and should be repeated if its
+        /// Recovery was running but has now finished. The action was not executed and should be repeated if its
         /// result is needed.  
         | RecoveryDone
     
@@ -532,10 +532,10 @@ module Actions =
     /// </para>
     /// <para>
     /// This version of persist will return persistence lifecycle events
-    /// in addition to the results of the action passed to persist. If something other than ActionResult is returned then
+    /// in addition to the results of the action passed to persist. If something other than ActionResult is returned, then
     /// the action was not executed. The action will also not be executed if the actor is recovering, instead the
     /// ActionExecuted values will be read from the event log until it runs out, at which point persist will return a
-    /// RecoveryDone value (the action will not have been executed, if it's result is needed then call persist again
+    /// RecoveryDone value (the action will not have been executed, if its result is needed, then call persist again
     /// to execute the action). If the persistence system rejects a result, then ActionResultRejected will be returned.
     /// If persisting an event fails, then the failure will be logged and the actor will stop.  
     /// </para>
@@ -571,10 +571,10 @@ module Actions =
     /// </para>
     /// <para>
     /// This version of persist will return persistence lifecycle events
-    /// in addition to the results of the action passed to persist. If something other than ActionResult is returned then
+    /// in addition to the results of the action passed to persist. If something other than ActionResult is returned, then
     /// the action was not executed. The action will also not be executed if the actor is recovering, instead the
     /// ActionExecuted values will be read from the event log until it runs out, at which point persist will return a
-    /// RecoveryDone value (the action will not have been executed, if it's result is needed then call persist again
+    /// RecoveryDone value (the action will not have been executed, if its result is needed, then call persist again
     /// to execute the action). If the persistence system rejects a result, then ActionResultRejected will be returned.
     /// If persisting an event fails, then the failure will be logged and the actor will stop.  
     /// </para>
@@ -606,8 +606,8 @@ module Actions =
     /// </para>
     /// <para>
     /// This version of persist will not return persistence lifecycle
-    /// events and if recovery fails or a result is rejected by the persistence system , then it will stop the actor.
-    /// If a result is produced then it was either read from the event log if recovering or the product of executing the
+    /// events, and if recovery fails or a result is rejected by the persistence system, then it will stop the actor.
+    /// If a result is produced, then it was either read from the event log if recovering or the product of executing the
     /// action if not recovering. Unlike persist, persistSimple will always execute its action.
     /// </para>
     /// </summary>
@@ -643,8 +643,8 @@ module Actions =
     /// </para>
     /// <para>
     /// This version of persist will not return persistence lifecycle
-    /// events and if recovery fails or a result is rejected by the persistence system , then it will stop the actor.
-    /// If a result is produced then it was either read from the event log if recovering or the product of executing the
+    /// events, and if recovery fails or a result is rejected by the persistence system, then it will stop the actor.
+    /// If a result is produced, then it was either read from the event log if recovering or the product of executing the
     /// action if not recovering. Unlike persist, persistSimple will always execute its action.
     /// </para>
     /// </summary>
@@ -681,7 +681,7 @@ module Actions =
         return (res :?> int64)
     }
     
-    /// Saves a snapshot of the actor's state. If you are interested in success/failure then watch for
+    /// Saves a snapshot of the actor's state. If you are interested in success or failure, then watch for
     /// Akka.Persistence.SaveSnapshotSuccess and/or Akka.Persistence.SaveSnapshotFailure messages or provide
     /// a snapshot result handler when starting the actor.  
     let saveSnapshot (snapshot: 'SnapShot) : SnapshotAction<unit, 'SnapShot> = actor {
@@ -689,21 +689,21 @@ module Actions =
         return ()
     }
 
-    /// Deletes events up to the given sequence number. If you are interested in success/failure then watch for
+    /// Deletes events up to the given sequence number. If you are interested in success or failure, then watch for
     /// Akka.Persistence.DeleteMessagesSuccess and/or Akka.Persistence.DeleteMessagesFailure messages.
     let deleteEvents (sequenceNr: int64) : SnapshotAction<unit, 'SnapShot> = actor {
         let! _ = Extra(Snapshot (DeleteEvents sequenceNr), Done)
         return ()
     }
 
-    /// Deletes snapshots up to the given sequence number. If you are interested in success/failure then watch for
+    /// Deletes snapshots up to the given sequence number. If you are interested in success or failure, then watch for
     /// Akka.Persistence.DeleteSnapshotSuccess and/or Akka.Persistence.DeleteSnapshotFailure messages.
     let deleteSnapshot (sequenceNr: int64) : SnapshotAction<unit, 'SnapShot> = actor {
         let! _ = Extra(Snapshot (DeleteSnapshot sequenceNr), Done)
         return ()
     }
     
-    /// Deletes snapshots that satisfy the given criteria. If you are interested in success/failure then watch for
+    /// Deletes snapshots that satisfy the given criteria. If you are interested in success or failure, then watch for
     /// Akka.Persistence.DeleteSnapshotsSuccess and/or Akka.Persistence.DeleteSnapshotsFailure messages.
     let deleteSnapshots (criteria: Akka.Persistence.SnapshotSelectionCriteria) : SnapshotAction<unit, 'SnapShot> = actor {
         let! _ = Extra(Snapshot (DeleteSnapshots criteria), Done)
@@ -729,7 +729,7 @@ module Actions =
     /// If true, then on snapshot success, all snapshots prior to the most recent are deleted.
     /// </param>
     /// <param name="errorHandler">
-    /// If given, it will be called if there is a snapshot save error. If it returns false then the actor will be
+    /// If given, it will be called if there is a snapshot save error. If it returns false, then the actor will be
     /// stopped. If not given, snapshot save errors will be logged only.
     /// </param>
     type SnapshotResultHandler(deletePriorMessages, deletePriorSnapshots, ?errorHandler) =
@@ -754,7 +754,7 @@ module Actions =
                     )
                     true
 
-    /// Removes a snapshot result handler that was registered using addSnapshotResultHandler. 
+    /// Removes a snapshot result handler registered using addSnapshotResultHandler. 
     let removeSnapshotResultHandler index : SnapshotAction<unit, 'Snapshot> = actor {
         let! _ = Extra(RemoveSnapshotResultHandler index, Done)
         return ()

--- a/WAkka/Wakka/Simple.fs
+++ b/WAkka/Wakka/Simple.fs
@@ -350,7 +350,7 @@ type SimpleActor (persist: bool, startAction: unit -> SimpleAction<unit>) as thi
         let onDone (ctx: ISimpleActionsContext, _res) = ctx.Ctx.Stop ctx.Ctx.Self
         let drainStartMsg cont = {
             // this gets rid of the Start message sent when the restarted actor constructor ran. We already got the
-            // Start message from the previous actor instance, if we don't get rid of the one from out constructor then
+            // Start message from the previous actor instance, if we don't get rid of the one from our constructor, then
             // repeated crashes with no other messages will cause the state to reset.
             new IMessageHandler with 
                 member this.HandleMessage msg =
@@ -449,7 +449,7 @@ and private Start = {
 
 /// <summary>
 /// Class that can be used to spawn notPersisted actors. Usually, Spawn.spawn should be used to spawn actors, but if
-/// you need a class type to use with Akka.Actor.Props.Create for special cases (like remote deployment) then a new class
+/// you need a class type to use with Akka.Actor.Props.Create for special cases (like remote deployment), then a new class
 /// can be derived from this class instead.  
 /// </summary>
 /// <param name="action">The action for the actor to run.</param>
@@ -461,7 +461,7 @@ type NotPersistedActor(action: unit -> SimpleAction<unit>) =
     
 /// <summary>
 /// Class that can be used to spawn checkpointed actors. Usually, Spawn.spawn should be used to spawn actors, but if
-/// you need a class type to use with Akka.Actor.Props.Create for special cases (like remote deployment) then a new class
+/// you need a class type to use with Akka.Actor.Props.Create for special cases (like remote deployment), then a new class
 /// can be derived from this class instead.
 /// </summary>
 /// <param name="action">The action for the actor to run.</param>
@@ -522,7 +522,7 @@ type Spawn () =
 let spawnNotPersisted parent props action = spawn parent props false (fun () -> action)
 
 /// <summary>
-/// Creates and actor that runs the given action. If the actor crashes then it restarts from the last point where it
+/// Creates an actor that runs the given action. If the actor crashes, then it restarts from the last point where it
 /// was waiting for a message. NOTE: This function is deprecated, use Simple.Spawn.Checkpointed instead.
 /// </summary>
 /// <param name="parent">The parent for the actor.</param>
@@ -650,7 +650,7 @@ module Actions =
     
      /// The result of handling a message via Receive.HandleMessages.
     type HandleMessagesResult<'Msg, 'Result> =
-        /// We are done handling messages with the given result. If HandleMessages was the only action in the actor then
+        /// We are done handling messages with the given result. If HandleMessages was the only action in the actor, then
         /// the actor will stop, else the result given here will be the result of the HandleMessages action. 
         | IsDone of 'Result
         /// Continue processing messages using the current message handling function.
@@ -725,7 +725,7 @@ module Actions =
             handle recv
             
         /// Wait for a message for which the given function returns `Some`. If the timeout is reached before an appropriate
-        /// message is received then None is returned. What to do with other messages received while filtering is given
+        /// message is received, then None is returned. What to do with other messages received while filtering is given
         /// by the otherMsg argument, it defaults to ignoreOthers.
         static member Filter (choose: obj -> Option<'Msg>, timeout: TimeSpan, ?otherMsg) =
             let otherMsg = defaultArg otherMsg ignoreOthers
@@ -776,7 +776,7 @@ module Actions =
                     None
             Receive.Filter (filter, ?otherMsg = otherMsg)
         /// Waits for a message of the given type to be received. If the timeout is reached before an appropriate
-        /// message is received then None is returned. What to do with other messages received while filtering is
+        /// message is received, then None is returned. What to do with other messages received while filtering is
         /// given by the otherMsg argument, it defaults to ignoreOthers.
         static member Only<'Msg> (timeout: TimeSpan, ?otherMsg) : SimpleAction<Option<'Msg>> =
             let filter (msg: obj) =
@@ -794,7 +794,7 @@ module Actions =
                 | _ -> None
             Receive.Filter (filterType, ?otherMsg = otherMsg)
         /// Waits for a message of the given type that passes the given filter to be received. If the timeout is reached
-        /// before an appropriate message is received then None is returned. What to do with other messages received
+        /// before an appropriate message is received, then None is returned. What to do with other messages received
         /// while filtering is given by the otherMsg argument, it defaults to ignoreOthers.
         static member FilterOnly<'Msg> (timeout: TimeSpan, filter: 'Msg -> bool, ?otherMsg) : SimpleAction<Option<'Msg>> =
             let filterType (msg: obj) =
@@ -899,7 +899,7 @@ let foldValues (func: 'a -> 'res -> SimpleAction<'res>) (init: 'res) (values: se
     }
     loop values init
 
-/// Executes body as long as condition evaluates to true
+/// Executes body as long as the condition evaluates to true
 let executeWhile (condition: SimpleAction<Option<'condRes>>) (body: 'condRes -> SimpleAction<unit>) : SimpleAction<unit> =
     let rec loop () = actor {
         match! condition with

--- a/WAkka/Wakka/Spawn.fs
+++ b/WAkka/Wakka/Spawn.fs
@@ -40,11 +40,11 @@ type ActorType =
 /// Creates an actor that goes back to the given action if it restarts. NOTE: This function is deprecated,
 /// use Simple.Spawn.NotPersisted instead.
 let notPersisted action = NotPersisted action
-/// Creates and actor that runs the given action. If the actor crashes then it restarts from the last point where it
+/// Creates an actor that runs the given action. If the actor crashes, then it restarts from the last point where it
 /// was waiting for a message. NOTE: This function is deprecated, use Simple.Spawn.Checkpointed instead.
 let checkpointed action = Checkpointed action
 /// Creates an actor that uses the Akka.NET persistence event sourcing mechanism. In the event of a restart, the actor
-/// will replay events that were stored using the EventSourced.Actions.persist action. NOTE: This function is deprecated,
+/// will replay events stored using the EventSourced.Actions.persist action. NOTE: This function is deprecated,
 /// use EventSourced.Spawn.NoSnapshots or EventSourced.Spawn.Snapshots instead.
 let eventSourced action = EventSourced action
 

--- a/WAkka/Wakka/WAkka.fsproj
+++ b/WAkka/Wakka/WAkka.fsproj
@@ -19,7 +19,7 @@
     <Description>Make creating certain types of Akka.NET actors easier in F#.</Description>
     <Copyright>Copyright (c) Wyatt Technology 2023</Copyright>
     <PackageTags>actors,Akka, akka,concurreny,akka.net,fsharp</PackageTags>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "9.0.0",
     "rollForward": "latestMinor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
The `deleteEvents` and `getLastSequenceNr` actions were only allowed in snapshot actions (e.g., those usable with `Spawn.WithSnapshots`. Those actions can now be used in all event-sourced actors.