### PR TITLE
Fixed actor result composability

### DIFF
--- a/WAkka/WAkkaTests/ActorResultTests-EventSourced.fs
+++ b/WAkka/WAkkaTests/ActorResultTests-EventSourced.fs
@@ -1,0 +1,346 @@
+// Copyright (c) 2022, Wyatt Technology Corporation
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module WAkkaTests.ActorResultEventSourcedTests
+
+
+open NUnit.Framework
+
+open Akkling
+
+open WAkka.Common
+open WAkka.EventSourced
+open WAkka.ActorResult
+module ws = WAkka.Simple
+
+// Couldn't figure out how to fit the EventSourced actor spawn functions into ActorResultTests.actorFunctions, so just
+// copying the tests here. Also, could not figure out how to fit WithSnapshots here either, so the tests are copied
+// again for those in ActorResultWithSnapshotsEventSourcedTests.fs
+type ActorFunction = Akka.Actor.IActorRefFactory * EventSourcedProps * (unit -> NoSnapshotsAction<unit>) -> IActorRef<obj>
+let actorFunctions : ActorFunction [] =[|Spawn.NoSnapshots|]
+
+let receiveMsg<'Msg> ()  = persistSimple (ws.Actions.Receive.Only<'Msg> ())
+
+[<Test>]
+let ``actor result: computation expression`` ([<ValueSource("actorFunctions")>] makeActor: ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun () ->
+                    let rec loop () =
+                        actor {
+                            let! res = actorResult {
+                                let! msg1 = receiveMsg<Result<int, string>>()
+                                do! ActorResult.ofActor ((typed probe) <! "intermediate message")
+                                let! msg2 = actorResult {
+                                    // this tests that actorResult expressions can be nested (this wasn't possible at one point)
+                                    return! receiveMsg<Result<int, string>>()
+                                }
+                                return msg1 + msg2
+                            }
+                            do! typed probe <! res
+                            return! loop ()
+                        }
+                    loop ()
+                )
+            )
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg "intermediate message" |> ignore
+        tellNow (retype act) (Result<int, string>.Ok 2)
+        probe.ExpectMsg (Result<int, string>.Ok 3) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg "intermediate message" |> ignore
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        probe.ExpectMsg (Result<int, string>.Error "err1") |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err2")
+        probe.ExpectMsg (Result<int, string>.Error "err2") |> ignore
+
+[<Test>]
+let ``actor result: orElse`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun () ->
+                    let rec loop () =
+                        actor {
+                            let! res =
+                                receiveMsg<Result<int, string>>()
+                                |> ActorResult.orElse (receiveMsg<Result<int, string>>())
+                            do! typed probe <! res
+                            return! loop ()
+                        }
+                    loop ()
+                )
+            )
+
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        tellNow (retype act) (Result<int, string>.Ok 2)
+        probe.ExpectMsg (Result<int, string>.Ok 2) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        tellNow (retype act) (Result<int, string>.Error "err2")
+        probe.ExpectMsg (Result<int, string>.Error "err2") |> ignore
+
+[<Test>]
+let ``actor result: orElseWith`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun () -> 
+                     let rec loop () = actor {
+                         let! res =
+                             receiveMsg<Result<int, string>>()
+                             |> ActorResult.orElseWith (fun err1 ->
+                                 tellNow (typed probe) err1
+                                 receiveMsg<Result<int, string>>()
+                             )
+                         do! typed probe <! res
+                         return! loop ()
+                     }
+                     loop ()
+                )
+            )
+
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        probe.ExpectMsg "err1" |> ignore
+        tellNow (retype act) (Result<int, string>.Ok 2)
+        probe.ExpectMsg (Result<int, string>.Ok 2) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        probe.ExpectMsg "err1" |> ignore
+        tellNow (retype act) (Result<int, string>.Error "err2")
+        probe.ExpectMsg (Result<int, string>.Error "err2") |> ignore
+
+[<Test>]
+let ``actor result: ignore`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun () ->
+                     let rec loop () = actor {
+                         let! msg = receiveMsg<Result<string, string>>() |> ActorResult.ignore
+                         do! typed probe <! msg
+
+                         return! loop ()
+                     }
+                     loop ()
+                 )
+            )
+
+        tellNow (retype act) (Result<string, string>.Ok "")
+        probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+        tellNow (retype act) (Result<string, string>.Error "err")
+        probe.ExpectMsg (Result<unit, string>.Error "err") |> ignore
+
+
+let testRequire makeActor require test =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun () ->
+                     let rec loop () = actor {
+                         let! msg = require
+                         do! typed probe <! msg
+
+                         return! loop ()
+                     }
+                     loop ()
+                 )
+            )
+        test act probe
+
+[<Test>]
+let ``actor result: requireTrue`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg () |> ActorResult.requireTrue "failed to get true")
+        (fun act probe ->
+            tellNow (retype act) true
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) false
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get true") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireFalse`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg () |> ActorResult.requireFalse "failed to get false")
+        (fun act probe ->
+            tellNow (retype act) false
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) true
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get false") |> ignore
+        )
+
+type WrapOption<'a> = {
+    value: Option<'a>
+}
+
+[<Test>]
+let ``actor result: requireSome`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<WrapOption<int>>() |> mapResult (fun w -> w.value) |> ActorResult.requireSome "failed to get some")
+        (fun act probe ->
+            tellNow (retype act) {value = Some 1}
+            probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+            tellNow (retype act) {value = Option<int>.None}
+            probe.ExpectMsg (Result<int, string>.Error "failed to get some") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireNone`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<WrapOption<int>>() |> mapResult (fun w -> w.value) |> ActorResult.requireNone "failed to get none")
+        (fun act probe ->
+            tellNow (retype act) {value = Option<int>.None}
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) {value = Some 1}
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get none") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireEqual`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (ActorResult.requireEqual 1 (receiveMsg()) "failed to get equal")
+        (fun act probe ->
+            tellNow (retype act) 1
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) 2
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get equal") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireEqualTo`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (ActorResult.requireEqualTo 1 "failed to get equal" (receiveMsg()))
+        (fun act probe ->
+            tellNow (retype act) 1
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) 2
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get equal") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireEmpty`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int []>() |> ActorResult.requireEmpty "failed to get empty")
+        (fun act probe ->
+            tellNow (retype act) Array.empty<int>
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) [|1|]
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get empty") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireNotEmpty`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int []>() |> ActorResult.requireNotEmpty "failed to get not empty")
+        (fun act probe ->
+            tellNow (retype act) [|1|]
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) Array.empty<int>
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get not empty") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireHead`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int []>() |> ActorResult.requireHead "failed to get first")
+        (fun act probe ->
+            tellNow (retype act) [|1|]
+            probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+            tellNow (retype act) Array.empty<int>
+            probe.ExpectMsg (Result<int, string>.Error "failed to get first") |> ignore
+        )
+
+[<Test>]
+let ``actor result: ofActor`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int>() |> ActorResult.ofActor)
+        (fun act probe ->
+            tellNow (retype act) 1
+            probe.ExpectMsg (Result<int, obj>.Ok 1) |> ignore
+        )
+
+[<Test>]
+let ``actor result: ofResult`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let _act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun () -> 
+                     actor {
+                         let! msg = Ok 1 |> ActorResult.ofResult
+                         do! typed probe <! msg
+                     }
+                 )
+            )
+        probe.ExpectMsg (Result<int, obj>.Ok 1) |> ignore
+

--- a/WAkka/WAkkaTests/ActorResultTests-WithSnapshotsEventSourced.fs
+++ b/WAkka/WAkkaTests/ActorResultTests-WithSnapshotsEventSourced.fs
@@ -1,0 +1,346 @@
+// Copyright (c) 2022, Wyatt Technology Corporation
+// All rights reserved.
+
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module WAkkaTests.ActorResultWithSnapshotsEventSourcedTests
+
+
+open NUnit.Framework
+
+open Akkling
+
+open WAkka.Common
+open WAkka.EventSourced
+open WAkka.ActorResult
+module ws = WAkka.Simple
+
+// Couldn't figure out how to fit the EventSourced actor spawn functions into ActorResultTests.actorFunctions, so just
+// copying the tests here. Also, could not figure out how to fit NoSnapshots here either, so the tests are copied
+// again for those in ActorResultEventSourcedTests.fs
+type ActorFunction = Akka.Actor.IActorRefFactory * EventSourcedProps * (Option<unit> -> SnapshotAction<unit, unit>) -> IActorRef<obj>
+let actorFunctions : ActorFunction [] =[|Spawn.WithSnapshots|]
+
+let receiveMsg<'Msg> ()  = persistSimple (ws.Actions.Receive.Only<'Msg> ())
+
+[<Test>]
+let ``actor result: computation expression`` ([<ValueSource("actorFunctions")>] makeActor: ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun _ ->
+                    let rec loop () =
+                        actor {
+                            let! res = actorResult {
+                                let! msg1 = receiveMsg<Result<int, string>>()
+                                do! ActorResult.ofActor ((typed probe) <! "intermediate message")
+                                let! msg2 = actorResult {
+                                    // this tests that actorResult expressions can be nested (this wasn't possible at one point)
+                                    return! receiveMsg<Result<int, string>>()
+                                }
+                                return msg1 + msg2
+                            }
+                            do! typed probe <! res
+                            return! loop ()
+                        }
+                    loop ()
+                )
+            )
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg "intermediate message" |> ignore
+        tellNow (retype act) (Result<int, string>.Ok 2)
+        probe.ExpectMsg (Result<int, string>.Ok 3) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg "intermediate message" |> ignore
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        probe.ExpectMsg (Result<int, string>.Error "err1") |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err2")
+        probe.ExpectMsg (Result<int, string>.Error "err2") |> ignore
+
+[<Test>]
+let ``actor result: orElse`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun _ ->
+                    let rec loop () =
+                        actor {
+                            let! res =
+                                receiveMsg<Result<int, string>>()
+                                |> ActorResult.orElse (receiveMsg<Result<int, string>>())
+                            do! typed probe <! res
+                            return! loop ()
+                        }
+                    loop ()
+                )
+            )
+
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        tellNow (retype act) (Result<int, string>.Ok 2)
+        probe.ExpectMsg (Result<int, string>.Ok 2) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        tellNow (retype act) (Result<int, string>.Error "err2")
+        probe.ExpectMsg (Result<int, string>.Error "err2") |> ignore
+
+[<Test>]
+let ``actor result: orElseWith`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun _ -> 
+                     let rec loop () = actor {
+                         let! res =
+                             receiveMsg<Result<int, string>>()
+                             |> ActorResult.orElseWith (fun err1 ->
+                                 tellNow (typed probe) err1
+                                 receiveMsg<Result<int, string>>()
+                             )
+                         do! typed probe <! res
+                         return! loop ()
+                     }
+                     loop ()
+                )
+            )
+
+        tellNow (retype act) (Result<int, string>.Ok 1)
+        probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        probe.ExpectMsg "err1" |> ignore
+        tellNow (retype act) (Result<int, string>.Ok 2)
+        probe.ExpectMsg (Result<int, string>.Ok 2) |> ignore
+
+        tellNow (retype act) (Result<int, string>.Error "err1")
+        probe.ExpectMsg "err1" |> ignore
+        tellNow (retype act) (Result<int, string>.Error "err2")
+        probe.ExpectMsg (Result<int, string>.Error "err2") |> ignore
+
+[<Test>]
+let ``actor result: ignore`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun _ ->
+                     let rec loop () = actor {
+                         let! msg = receiveMsg<Result<string, string>>() |> ActorResult.ignore
+                         do! typed probe <! msg
+
+                         return! loop ()
+                     }
+                     loop ()
+                 )
+            )
+
+        tellNow (retype act) (Result<string, string>.Ok "")
+        probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+        tellNow (retype act) (Result<string, string>.Error "err")
+        probe.ExpectMsg (Result<unit, string>.Error "err") |> ignore
+
+
+let testRequire makeActor require test =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun _ ->
+                     let rec loop () = actor {
+                         let! msg = require
+                         do! typed probe <! msg
+
+                         return! loop ()
+                     }
+                     loop ()
+                 )
+            )
+        test act probe
+
+[<Test>]
+let ``actor result: requireTrue`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg () |> ActorResult.requireTrue "failed to get true")
+        (fun act probe ->
+            tellNow (retype act) true
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) false
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get true") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireFalse`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg () |> ActorResult.requireFalse "failed to get false")
+        (fun act probe ->
+            tellNow (retype act) false
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) true
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get false") |> ignore
+        )
+
+type WrapOption<'a> = {
+    value: Option<'a>
+}
+
+[<Test>]
+let ``actor result: requireSome`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<WrapOption<int>>() |> mapResult (fun w -> w.value) |> ActorResult.requireSome "failed to get some")
+        (fun act probe ->
+            tellNow (retype act) {value = Some 1}
+            probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+            tellNow (retype act) {value = Option<int>.None}
+            probe.ExpectMsg (Result<int, string>.Error "failed to get some") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireNone`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<WrapOption<int>>() |> mapResult (fun w -> w.value) |> ActorResult.requireNone "failed to get none")
+        (fun act probe ->
+            tellNow (retype act) {value = Option<int>.None}
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) {value = Some 1}
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get none") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireEqual`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (ActorResult.requireEqual 1 (receiveMsg()) "failed to get equal")
+        (fun act probe ->
+            tellNow (retype act) 1
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) 2
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get equal") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireEqualTo`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (ActorResult.requireEqualTo 1 "failed to get equal" (receiveMsg()))
+        (fun act probe ->
+            tellNow (retype act) 1
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) 2
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get equal") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireEmpty`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int []>() |> ActorResult.requireEmpty "failed to get empty")
+        (fun act probe ->
+            tellNow (retype act) Array.empty<int>
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) [|1|]
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get empty") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireNotEmpty`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int []>() |> ActorResult.requireNotEmpty "failed to get not empty")
+        (fun act probe ->
+            tellNow (retype act) [|1|]
+            probe.ExpectMsg (Result<unit, string>.Ok ()) |> ignore
+            tellNow (retype act) Array.empty<int>
+            probe.ExpectMsg (Result<unit, string>.Error "failed to get not empty") |> ignore
+        )
+
+[<Test>]
+let ``actor result: requireHead`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int []>() |> ActorResult.requireHead "failed to get first")
+        (fun act probe ->
+            tellNow (retype act) [|1|]
+            probe.ExpectMsg (Result<int, string>.Ok 1) |> ignore
+            tellNow (retype act) Array.empty<int>
+            probe.ExpectMsg (Result<int, string>.Error "failed to get first") |> ignore
+        )
+
+[<Test>]
+let ``actor result: ofActor`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    testRequire
+        makeActor
+        (receiveMsg<int>() |> ActorResult.ofActor)
+        (fun act probe ->
+            tellNow (retype act) 1
+            probe.ExpectMsg (Result<int, obj>.Ok 1) |> ignore
+        )
+
+[<Test>]
+let ``actor result: ofResult`` ([<ValueSource("actorFunctions")>] makeActor:  ActorFunction) =
+    TestKit.testDefault <| fun tk ->
+        let probe = tk.CreateTestProbe "probe"
+
+        let _act =
+            makeActor(
+                tk.Sys,
+                EventSourcedProps.Named "ce-test",
+                (fun _ -> 
+                     actor {
+                         let! msg = Ok 1 |> ActorResult.ofResult
+                         do! typed probe <! msg
+                     }
+                 )
+            )
+        probe.ExpectMsg (Result<int, obj>.Ok 1) |> ignore
+

--- a/WAkka/WAkkaTests/WAkkaTests.fsproj
+++ b/WAkka/WAkkaTests/WAkkaTests.fsproj
@@ -29,6 +29,8 @@
     <ItemGroup>
       <Compile Include="SimpleTests.fs" />
       <Compile Include="ActorResultTests.fs" />
+      <Compile Include="ActorResultTests-EventSourced.fs" />
+      <Compile Include="ActorResultTests-WithSnapshotsEventSourced.fs" />
       <Compile Include="NotPersistedTests.fs" />
       <Compile Include="CheckpointedTests.fs" />
       <Compile Include="EventSourcedTests.fs" />

--- a/WAkka/Wakka/ActorResult.fs
+++ b/WAkka/Wakka/ActorResult.fs
@@ -36,32 +36,32 @@ open Common
 open Simple
 
 /// Combines a SimpleAction and a Result.
-type ActorResult<'result, 'error> = SimpleAction<Result<'result, 'error>>
+type ActorResult<'result, 'error, 'extra> = ActionBase<Result<'result, 'error>, 'extra>
 
 [<RequireQualifiedAccess>]
 module ActorResult =
 
     /// Wraps the given value in an ActorResult so that the ActorResult evaluates to "Ok value".
-    let inline retn (value: 'res) : ActorResult<'res, 'err> = value |> Ok |> actor.Return
+    let inline retn (value: 'res) : ActorResult<'res, 'err, 'extra> = value |> Ok |> actor.Return
     /// Wraps the given value in an ActorResult so that the ActorResult evaluates to "Ok value".
-    let inline ok  (value: 'res) : ActorResult<'res, 'err> = retn value
+    let inline ok  (value: 'res) : ActorResult<'res, 'err, 'extra> = retn value
     /// Wraps the given value in an ActorResult so that the ActorResult evaluates to "Error value".
-    let inline returnError (value: 'err) : ActorResult<'res, 'err> = value |> Error |> actor.Return
+    let inline returnError (value: 'err) : ActorResult<'res, 'err, 'extra> = value |> Error |> actor.Return
     /// Wraps the given value in an ActorResult so that the ActorResult evaluates to "Error value".
-    let inline error (value: 'err) : ActorResult<'res, 'err> = returnError value
+    let inline error (value: 'err) : ActorResult<'res, 'err, 'extra> = returnError value
 
     /// Applies the given function to the value of the given ActorResult if the ActorResult evaluates to Ok.
-    let inline map (f: 'res1 -> 'res2) (action: ActorResult<'res1, 'err>) : ActorResult<'res2, 'err> =
+    let inline map (f: 'res1 -> 'res2) (action: ActorResult<'res1, 'err, 'extra>) : ActorResult<'res2, 'err, 'extra> =
         action |> mapResult (Result.map f)
     /// Applies the given function to the value of the given ActorResult if the ActorResult evaluates to Error.
-    let inline mapError (f: 'err1 -> 'err2) (action: ActorResult<'res, 'err1>) : ActorResult<'res, 'err2> =
+    let inline mapError (f: 'err1 -> 'err2) (action: ActorResult<'res, 'err1, 'extra>) : ActorResult<'res, 'err2, 'extra> =
         action |> mapResult (Result.mapError f)
 
     /// Binds two ActorResults together.
     let inline bind
-        (binder: 'input -> ActorResult<'output, 'error>)
-        (input: ActorResult<'input, 'error>)
-        : ActorResult<'output, 'error> =
+        (binder: 'input -> ActorResult<'output, 'error, 'extra>)
+        (input: ActorResult<'input, 'error, 'extra>)
+        : ActorResult<'output, 'error, 'extra> =
         bindBase (Result.either binder returnError) input
 
     /// <summary>
@@ -83,9 +83,9 @@ module ActorResult =
     /// The result if the result is Ok, else returns <paramref name="ifError"/>.
     /// </returns>
     let inline orElse
-        (ifError: ActorResult<'ok, 'errorOutput>)
-        (input: ActorResult<'ok, 'errorInput>)
-        : ActorResult<'ok, 'errorOutput> =
+        (ifError: ActorResult<'ok, 'errorOutput, 'extra>)
+        (input: ActorResult<'ok, 'errorInput, 'extra>)
+        : ActorResult<'ok, 'errorOutput, 'extra> =
         bindBase (Result.either ok (fun _ -> ifError)) input
 
     /// <summary>
@@ -108,55 +108,55 @@ module ActorResult =
     /// The result if the result is Ok, else the result of executing <paramref name="ifErrorFunc"/>.
     /// </returns>
     let inline orElseWith
-        (ifErrorFunc: 'errorInput -> ActorResult<'ok, 'errorOutput>)
-        (input: ActorResult<'ok, 'errorInput>)
-        : ActorResult<'ok, 'errorOutput> =
+        (ifErrorFunc: 'errorInput -> ActorResult<'ok, 'errorOutput, 'extra>)
+        (input: ActorResult<'ok, 'errorInput, 'extra>)
+        : ActorResult<'ok, 'errorOutput, 'extra> =
         bindBase (Result.either ok ifErrorFunc) input
 
     /// Replaces the wrapped value with unit
-    let inline ignore<'ok, 'error> (value: ActorResult<'ok, 'error>) : ActorResult<unit, 'error> =
+    let inline ignore<'ok, 'error, 'extra> (value: ActorResult<'ok, 'error, 'extra>) : ActorResult<unit, 'error, 'extra> =
         value |> map ignore<'ok>
 
     /// Returns the specified error if the async-wrapped value is false.
-    let inline requireTrue (err: 'err) (action: SimpleAction<bool>): ActorResult<unit, 'err> =
+    let inline requireTrue (err: 'err) (action: ActionBase<bool, 'extra>): ActorResult<unit, 'err, 'extra> =
         action |> mapResult (Result.requireTrue err)
     /// Returns the specified error if the async-wrapped value is true.
-    let inline requireFalse (err: 'err) (action: SimpleAction<bool>): ActorResult<unit, 'err> =
+    let inline requireFalse (err: 'err) (action: ActionBase<bool, 'extra>): ActorResult<unit, 'err, 'extra> =
         action |> mapResult (Result.requireFalse err)
 
     /// Converts an async-wrapped Option to a Result, using the given error if None.
-    let inline requireSome (err: 'err) (action: SimpleAction<Option<'res>>): ActorResult<'res, 'err> =
+    let inline requireSome (err: 'err) (action: ActionBase<Option<'res>, 'extra>): ActorResult<'res, 'err, 'extra> =
         action |> mapResult (Result.requireSome err)
     /// Converts an async-wrapped Option to a Result, using the given error if Some.
-    let inline requireNone (err: 'err) (action: SimpleAction<Option<'res>>): ActorResult<unit, 'err> =
+    let inline requireNone (err: 'err) (action: ActionBase<Option<'res>, 'extra>): ActorResult<unit, 'err, 'extra> =
         action |> mapResult (Result.requireNone err)
 
     /// Returns Ok if the async-wrapped value and the provided value are equal, or the specified error if not.
-    let inline requireEqual (value1: 'value) (value2: SimpleAction<'value>) (error: 'error) : ActorResult<unit, 'error> =
+    let inline requireEqual (value1: 'value) (value2: ActionBase<'value, 'extra>) (error: 'error) : ActorResult<unit, 'error, 'extra> =
         value2 |> mapResult (fun x2' -> Result.requireEqual value1 x2' error)
 
     /// Returns Ok if the two values are equal, or the specified error if not.
-    let inline requireEqualTo (other: 'value) (error: 'error) (this: SimpleAction<'value>) : ActorResult<unit, 'error> =
+    let inline requireEqualTo (other: 'value) (error: 'error) (this: ActionBase<'value, 'extra>) : ActorResult<unit, 'error, 'extra> =
         this |> mapResult (Result.requireEqualTo other error)
 
     /// Returns Ok if the async-wrapped sequence is empty, or the specified error if not.
-    let inline requireEmpty (error: 'error) (values: SimpleAction<#seq<'ok>>) : ActorResult<unit, 'error> =
+    let inline requireEmpty (error: 'error) (values: ActionBase<#seq<'ok>, 'extra>) : ActorResult<unit, 'error, 'extra> =
         values |> mapResult (Result.requireEmpty error)
 
     /// Returns Ok if the async-wrapped sequence is not-empty, or the specified error if not.
-    let inline requireNotEmpty (error: 'error) (values: SimpleAction<#seq<'ok>>) : ActorResult<unit, 'error> =
+    let inline requireNotEmpty (error: 'error) (values: ActionBase<#seq<'ok>, 'extra>) : ActorResult<unit, 'error, 'extra> =
         values |> mapResult (Result.requireNotEmpty error)
 
     /// Returns the first item of the async-wrapped sequence if it exists, or the specified
     /// error if the sequence is empty
-    let inline requireHead (error: 'error) (values: SimpleAction<#seq<'ok>>) : ActorResult<'ok, 'error> =
+    let inline requireHead (error: 'error) (values: ActionBase<#seq<'ok>, 'extra>) : ActorResult<'ok, 'error, 'extra> =
         values |> mapResult (Result.requireHead error)
 
     /// Lift SimpleAction to ActorResult
-    let inline ofActor (value: SimpleAction<'ok>) : ActorResult<'ok, 'error> = value |> mapResult Ok
+    let inline ofActor (value: ActionBase<'ok, 'extra>) : ActorResult<'ok, 'error, 'extra> = value |> mapResult Ok
 
     /// Lift Result to ActorResult
-    let inline ofResult (value: Result<'ok, 'error>) : ActorResult<'ok, 'error> = actor.Return value
+    let inline ofResult (value: Result<'ok, 'error>) : ActorResult<'ok, 'error, 'extra> = actor.Return value
 
 
 [<AutoOpen>]
@@ -164,31 +164,30 @@ module ActorResultCE =
 
     type ActorResultBuilder () =
 
-        member inline _.Return (value: 'res) : SimpleAction<Result<'res, 'err>> = value |> result.Return |> actor.Return
-        member inline _.ReturnFrom (value: SimpleAction<Result<'ok, 'err>>) = value
-        member inline _.Zero() : SimpleAction<Result<unit, 'error>> = result.Zero() |> actor.Return
-        member inline _.Bind(result: ActorResult<'okInput, 'error>,
-                             binder: 'okInput -> ActorResult<'okOutput, 'error>
-                             ) : SimpleAction<Result<'okOutput, 'error>> =
+        member inline _.Return (value: 'res) : ActionBase<Result<'res, 'err>, 'extra> = value |> result.Return |> actor.Return
+        member inline _.ReturnFrom (value: ActionBase<Result<'ok, 'err>, 'extra>) = value
+        member inline _.Zero() : ActionBase<Result<unit, 'error>, 'extra> = result.Zero() |> actor.Return
+        member inline _.Bind(result: ActorResult<'okInput, 'error, 'extra>,
+                             binder: 'okInput -> ActorResult<'okOutput, 'error, 'extra>
+                             ) : ActionBase<Result<'okOutput, 'error>, 'extra> =
             ActorResult.bind binder result
-        member inline _.Delay (generator: unit -> SimpleAction<Result<'ok, 'error>>) : SimpleAction<Result<'ok, 'error>> =
+        member inline _.Delay (generator: unit -> ActionBase<Result<'ok, 'error>, 'extra>) : ActionBase<Result<'ok, 'error>, 'extra> =
             generator ()
         member inline this.Combine
             (
-                computation1: SimpleAction<Result<unit, 'error>>,
-                computation2: SimpleAction<Result<'ok, 'error>>
-            ) : SimpleAction<Result<'ok, 'error>> =
+                computation1: ActionBase<Result<unit, 'error>, 'extra>,
+                computation2: ActionBase<Result<'ok, 'error>, 'extra>
+            ) : ActionBase<Result<'ok, 'error>, 'extra> =
             this.Bind(computation1, (fun () -> computation2))
 
-    /// A computation expression that allows mixing of SimpleAction and Result via the type ActorResult<'res, 'err> which
-    /// is equivalent to SimpleAction<Result<'res, 'err>>. The CE unwraps both types so that "let! value = f ()" where
-    /// "f: unit -> SimpleAction<Result<'res, 'err>>" would evaluate the action returned by "f ()" and then unwrap the
+    /// A computation expression that allows mixing of actor actions and Result via the type ActorResult<'res, 'err, 'extra> which
+    /// is equivalent to ActionBase<Result<'res, 'err>, 'extra>. The CE unwraps both types so that "let! value = f ()" where
+    /// "f: unit -> ActionBase<Result<'res, 'err>, 'extra>" would evaluate the action returned by "f ()" and then unwrap the
     /// Result that the action evaluated to. If the result is "Ok okValue" then "okValue" is bound to "value". If the
     /// result is "Error err" then the "actorResult" CE terminates with a value of "Error err". Note that the right
-    /// side of a "let! ... = ..." must evaluate to "SimpleAction<Result<'res, 'err>>". There are numerous functions in
+    /// side of a "let! ... = ..." must evaluate to "ActionBase<Result<'res, 'err>, 'extra>". There are numerous functions in
     /// the ActorResult module that can help convert other types (booleans, options, etc.) into the proper type.
-    /// "actorResult" computations can be directly run in actor expressions (e.g.,
-    /// "actor {let! res = actorResult { ... }; ...}").
+    /// "actorResult" computations can be directly run in actor expressions (e.g., "actor {let! res = actorResult { ... }; ...}").
     let actorResult = ActorResultBuilder()
     
     /// Evaluates an actorResult computation expression. This is only here for backwards compatibility, actorResult

--- a/WAkka/Wakka/ActorResult.fs
+++ b/WAkka/Wakka/ActorResult.fs
@@ -171,8 +171,8 @@ module ActorResultCE =
                              binder: 'okInput -> ActorResult<'okOutput, 'error>
                              ) : SimpleAction<Result<'okOutput, 'error>> =
             ActorResult.bind binder result
-        member inline _.Delay (generator: unit -> SimpleAction<Result<'ok, 'error>>) : Delayed<Result<'ok, 'error>> =
-            actor.Delay generator
+        member inline _.Delay (generator: unit -> SimpleAction<Result<'ok, 'error>>) : SimpleAction<Result<'ok, 'error>> =
+            generator ()
         member inline this.Combine
             (
                 computation1: SimpleAction<Result<unit, 'error>>,
@@ -186,9 +186,12 @@ module ActorResultCE =
     /// Result that the action evaluated to. If the result is "Ok okValue" then "okValue" is bound to "value". If the
     /// result is "Error err" then the "actorResult" CE terminates with a value of "Error err". Note that the right
     /// side of a "let! ... = ..." must evaluate to "SimpleAction<Result<'res, 'err>>". There are numerous functions in
-    /// the ActorResult module that can help convert other types (booleans, options, etc.) into the proper type. The
-    /// "actorResult" CE produces a "Delayed<Result<'res, 'err>>" and must be passed to runActorResult for evaluation.
+    /// the ActorResult module that can help convert other types (booleans, options, etc.) into the proper type.
+    /// "actorResult" computations can be directly run in actor expressions (e.g.,
+    /// "actor {let! res = actorResult { ... }; ...}").
     let actorResult = ActorResultBuilder()
-    /// Evaluates an actorResult computation expression.
-    let runActorResult (res: Delayed<Result<'res, 'err>>) = res ()
+    
+    /// Evaluates an actorResult computation expression. This is only here for backwards compatibility, actorResult
+    /// computations can now be directly run in actor expressions (e.g., "actor {let! res = actorResult { ... }; ...}").
+    let runActorResult (res: SimpleAction<Result<'res, 'err>>) = res
 


### PR DESCRIPTION
`actorResult` can now be used directly in an `actor` computation expression without the need of `runActorResult`. Usages of `actorResult` can now be nested as well. Finally, `actorResult` can be used in event sourced actors as well as simple actors.